### PR TITLE
Add a release version prep script

### DIFF
--- a/docs/release/distribution-strategy.md
+++ b/docs/release/distribution-strategy.md
@@ -48,7 +48,7 @@ That makes a GitHub Releases-first approach the cleanest fit for `v0.0.1`.
 The release flow should mirror SMDU closely:
 
 1. Merge the release-ready PR into `main`.
-2. Run `scripts/prepare-release-version.sh --version <next-version>` in a clean working tree to update release-facing version references before tagging.
+2. Run `scripts/prepare-release-version.sh --version <next-version>` in a clean working tree to create a release-bump branch and update release-facing version references before tagging.
 3. Confirm release notes and docs reflect the merged behaviour.
 4. Create a tag such as `v0.0.1`.
 5. Let GitHub Actions build Linux artefacts for both supported architectures.
@@ -66,6 +66,12 @@ Before tagging a release, use:
 scripts/prepare-release-version.sh --version 0.0.3
 ```
 
+By default, this creates and switches to a branch named `chore/release-v0.0.3` before updating files. You can override that with:
+
+```bash
+scripts/prepare-release-version.sh --version 0.0.3 --branch chore/my-custom-release-branch
+```
+
 The script updates release-facing version references in:
 
 - `Cargo.toml`
@@ -73,7 +79,7 @@ The script updates release-facing version references in:
 - `README.md`
 - `docs/release/distribution-strategy.md`
 
-It expects a clean working tree and is designed to be run on a branch that will be reviewed and merged before the final tag is created on `main`.
+It expects a clean working tree and is designed to prepare a branch that will be reviewed and merged before the final tag is created on `main`.
 
 ## GitHub Actions shape
 

--- a/scripts/prepare-release-version.sh
+++ b/scripts/prepare-release-version.sh
@@ -26,15 +26,25 @@ fi
 
 usage() {
 	cat <<'USAGE'
-Usage: scripts/prepare-release-version.sh --version <version> [--dry-run]
+Usage:
+  scripts/prepare-release-version.sh --current-version
+  scripts/prepare-release-version.sh --version <version> [--branch <name>] [--dry-run]
 
 Options:
+  --current-version     Print the current workspace version and exit
   --version <version>   New release version, with or without a leading `v`
+  --branch <name>       Branch to create before updating files
   --dry-run             Show planned changes without writing files
   -h, --help            Show this help
 
 This script updates release-facing version references and prepares the repo for
 review before a release tag is created on `main`.
+
+Examples:
+  scripts/prepare-release-version.sh --current-version
+  scripts/prepare-release-version.sh --version 0.0.3
+  scripts/prepare-release-version.sh --version 0.0.3 --branch chore/my-release-branch
+  scripts/prepare-release-version.sh --version 0.0.3 --dry-run
 USAGE
 }
 
@@ -55,10 +65,20 @@ fail() {
 	exit 1
 }
 
+usage_error() {
+	printf '%b\n\n' "${RED}${1}${RESET}" >&2
+	usage >&2
+	exit 1
+}
+
 require_clean_repo() {
 	if ! git -C "${REPO_ROOT}" diff --quiet || ! git -C "${REPO_ROOT}" diff --cached --quiet; then
 		fail "Working tree has tracked changes. Commit or stash them before running this script."
 	fi
+}
+
+current_branch() {
+	git -C "${REPO_ROOT}" branch --show-current
 }
 
 current_workspace_version() {
@@ -74,12 +94,28 @@ replace_in_file() {
 }
 
 VERSION_INPUT=""
+BRANCH_INPUT=""
+SHOW_CURRENT_VERSION=false
 DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
+		--current-version)
+			SHOW_CURRENT_VERSION=true
+			shift
+			;;
 		--version)
-			VERSION_INPUT="${2:-}"
+			if [[ $# -lt 2 || -z "${2:-}" ]]; then
+				usage_error "Missing value for --version"
+			fi
+			VERSION_INPUT="${2}"
+			shift 2
+			;;
+		--branch)
+			if [[ $# -lt 2 || -z "${2:-}" ]]; then
+				usage_error "Missing value for --branch"
+			fi
+			BRANCH_INPUT="${2}"
 			shift 2
 			;;
 		--dry-run)
@@ -91,17 +127,31 @@ while [[ $# -gt 0 ]]; do
 			exit 0
 			;;
 		*)
-			fail "Unknown option: $1"
+			usage_error "Unknown option: $1"
 			;;
 	esac
 done
 
+if [[ "${SHOW_CURRENT_VERSION}" == true ]]; then
+	if [[ -n "${VERSION_INPUT}" || -n "${BRANCH_INPUT}" || "${DRY_RUN}" == true ]]; then
+		usage_error "--current-version cannot be combined with other options"
+	fi
+
+	CURRENT_VERSION="$(current_workspace_version)"
+	if [[ -z "${CURRENT_VERSION}" ]]; then
+		fail "Could not determine the current workspace version from Cargo.toml"
+	fi
+
+	printf '%s\n' "${CURRENT_VERSION}"
+	exit 0
+fi
+
 if [[ -z "${VERSION_INPUT}" ]]; then
-	fail "Missing required option: --version"
+	usage_error "Missing required option: --version or --current-version"
 fi
 
 if [[ ! "${VERSION_INPUT}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-	fail "Version must look like 0.0.3 or v0.0.3"
+	usage_error "Version must look like 0.0.3 or v0.0.3"
 fi
 
 require_clean_repo
@@ -114,6 +164,7 @@ fi
 NEW_VERSION="${VERSION_INPUT#v}"
 CURRENT_TAG="v${CURRENT_VERSION}"
 NEW_TAG="v${NEW_VERSION}"
+TARGET_BRANCH="${BRANCH_INPUT:-chore/release-${NEW_TAG}}"
 
 if [[ "${CURRENT_VERSION}" == "${NEW_VERSION}" ]]; then
 	fail "Version is already ${NEW_VERSION}"
@@ -128,6 +179,7 @@ FILES=(
 
 info "${BOLD}Preparing release version bump${RESET}"
 printf '  from %b%s%b to %b%s%b\n' "${YELLOW}" "${CURRENT_VERSION}" "${RESET}" "${GREEN}" "${NEW_VERSION}" "${RESET}"
+printf '  on branch %b%s%b\n' "${GREEN}" "${TARGET_BRANCH}" "${RESET}"
 
 for file in "${FILES[@]}"; do
 	if [[ ! -f "${file}" ]]; then
@@ -137,10 +189,21 @@ done
 
 if [[ "${DRY_RUN}" == true ]]; then
 	warn "Dry run only. No files will be changed."
+	printf '  would create or reuse branch %s\n' "${TARGET_BRANCH}"
 	for file in "${FILES[@]}"; do
 		printf '  would update %s\n' "${file#${REPO_ROOT}/}"
 	done
 	exit 0
+fi
+
+CURRENT_BRANCH_NAME="$(current_branch)"
+if [[ "${CURRENT_BRANCH_NAME}" != "${TARGET_BRANCH}" ]]; then
+	if git -C "${REPO_ROOT}" show-ref --verify --quiet "refs/heads/${TARGET_BRANCH}"; then
+		fail "Branch already exists locally: ${TARGET_BRANCH}"
+	fi
+
+	info "Creating branch ${TARGET_BRANCH}"
+	git -C "${REPO_ROOT}" checkout -b "${TARGET_BRANCH}" >/dev/null
 fi
 
 replace_in_file "${REPO_ROOT}/Cargo.toml" "version = \"${CURRENT_VERSION}\"" "version = \"${NEW_VERSION}\""
@@ -157,5 +220,6 @@ done
 warn "Next steps:"
 printf '  1. review the diff\n'
 printf '  2. run cargo checks\n'
-printf '  3. merge the PR to main\n'
-printf '  4. create tag %b%s%b on main\n' "${BOLD}" "${NEW_TAG}" "${RESET}"
+printf '  3. commit and open a PR from %b%s%b\n' "${BOLD}" "${TARGET_BRANCH}" "${RESET}"
+printf '  4. merge the PR to main\n'
+printf '  5. create tag %b%s%b on main\n' "${BOLD}" "${NEW_TAG}" "${RESET}"


### PR DESCRIPTION
## Summary

- **Release prep scripting** now includes `scripts/prepare-release-version.sh` to update release-facing version references before a new tag is created.
- **Safer release prep output** now includes coloured status messages plus a clean-working-tree guard so version-bump prep is harder to run in a half-finished state.
- **Release documentation** now includes the version-prep step in the release flow and points to the new script before tagging `main`.

## Test plan

- [x] `bash -n scripts/prepare-release-version.sh`
- [x] `scripts/prepare-release-version.sh --help`
- [x] Temporary clean-repo smoke test: run `scripts/prepare-release-version.sh --version 0.0.3` and confirm it updates `Cargo.toml`, `Cargo.lock`, `README.md`, and `docs/release/distribution-strategy.md`
