### PR TITLE
Rename Linux release artefacts to amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,8 +153,8 @@ jobs:
         include:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            arch: x64
-            artefact_suffix: linux-x64
+            arch: amd64
+            artefact_suffix: linux-amd64
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             arch: arm64

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Example package installs:
 
 ```bash
 # Debian/Ubuntu
-sudo dpkg -i flo-v0.0.4-linux-x64.deb
+sudo dpkg -i flo-v0.0.4-linux-amd64.deb
 
 # Fedora/RHEL/openSUSE
-sudo rpm -i flo-v0.0.4-linux-x64.rpm
+sudo rpm -i flo-v0.0.4-linux-amd64.rpm
 ```
 
 ### Manual archive installs
@@ -84,7 +84,7 @@ share/man/man1/flo-*.1.gz
 Example manual install into `/usr/local`:
 
 ```bash
-tar -xzf flo-v0.0.4-linux-x64.tar.gz
+tar -xzf flo-v0.0.4-linux-amd64.tar.gz
 sudo install -Dm755 bin/flo /usr/local/bin/flo
 sudo install -Dm644 share/man/man1/flo.1.gz /usr/local/share/man/man1/flo.1.gz
 sudo install -d /usr/local/share/man/man1

--- a/docs/release/distribution-strategy.md
+++ b/docs/release/distribution-strategy.md
@@ -101,7 +101,7 @@ Recommended matrix for the first pass:
 
 | runner | target triple | target label | architecture |
 |---|---|---|---|
-| `ubuntu-22.04` | `x86_64-unknown-linux-gnu` | `linux-x64` | `amd64` |
+| `ubuntu-22.04` | `x86_64-unknown-linux-gnu` | `linux-amd64` | `amd64` |
 | `ubuntu-22.04-arm` | `aarch64-unknown-linux-gnu` | `linux-arm64` | `arm64` |
 
 The workflow should pin fixed GitHub-hosted runner images rather than using `-latest` aliases so the release environment remains predictable over time.
@@ -124,13 +124,13 @@ Recommended workflow details:
 
 Release asset naming should stay predictable and match the SMDU style:
 
-- `flo-<tag>-linux-x64`
+- `flo-<tag>-linux-amd64`
 - `flo-<tag>-linux-arm64`
-- `flo-<tag>-linux-x64.tar.gz`
+- `flo-<tag>-linux-amd64.tar.gz`
 - `flo-<tag>-linux-arm64.tar.gz`
-- `flo-<tag>-linux-x64.deb`
+- `flo-<tag>-linux-amd64.deb`
 - `flo-<tag>-linux-arm64.deb`
-- `flo-<tag>-linux-x64.rpm`
+- `flo-<tag>-linux-amd64.rpm`
 - `flo-<tag>-linux-arm64.rpm`
 - corresponding `.sha256` files for every artefact above
 

--- a/scripts/build-linux-packages.sh
+++ b/scripts/build-linux-packages.sh
@@ -29,7 +29,7 @@ Usage: scripts/build-linux-packages.sh [options]
 
 Options:
   --version <version>         Package version or tag (for example, v0.0.1)
-  --arch <x64|arm64>          Target architecture
+  --arch <amd64|arm64>        Target architecture
   --binary <path>             Built binary path
   --man-dir <path>            Directory containing generated man pages
   --output-prefix <prefix>    Output file prefix (without extension)
@@ -60,8 +60,8 @@ write_sha256_file() {
 # Collapse common architecture aliases onto the two release architectures we support.
 normalise_arch() {
 	case "$1" in
-		x64 | amd64 | x86_64)
-			echo "x64"
+		amd64 | x86_64)
+			echo "amd64"
 			;;
 		arm64 | aarch64)
 			echo "arm64"
@@ -178,7 +178,7 @@ DEB_ARCH=""
 RPM_ARCH=""
 RPM_TARGET=""
 case "${ARCH}" in
-	x64)
+	amd64)
 		DEB_ARCH="amd64"
 		RPM_ARCH="x86_64"
 		RPM_TARGET="x86_64-linux"

--- a/scripts/build-release-archive.sh
+++ b/scripts/build-release-archive.sh
@@ -21,7 +21,7 @@ Usage: scripts/build-release-archive.sh [options]
 
 Options:
   --version <version>         Release version or tag (for example, v0.0.1)
-  --arch <x64|arm64>          Target architecture
+  --arch <amd64|arm64>        Target architecture
   --binary <path>             Built binary path
   --man-dir <path>            Directory containing generated man pages
   --output-prefix <prefix>    Output file prefix (without extension)
@@ -51,8 +51,8 @@ write_sha256_file() {
 # Collapse common architecture aliases onto the two release architectures we support.
 normalise_arch() {
 	case "$1" in
-		x64 | amd64 | x86_64)
-			echo "x64"
+		amd64 | x86_64)
+			echo "amd64"
 			;;
 		arm64 | aarch64)
 			echo "arm64"


### PR DESCRIPTION
## Summary
### Release labelling
- **Future Linux release assets** now use `linux-amd64` instead of `linux-x64`.
- **Build targets** remain unchanged at `x86_64-unknown-linux-gnu`; this only changes the release-facing name.
- **Docs and install examples** were updated to match the new naming.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo build`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test`
- [x] `bash -n scripts/build-release-archive.sh scripts/build-linux-packages.sh scripts/prepare-release-version.sh`
- [x] `git diff --check`
