### PR TITLE
docs: desktop UX exploration and the chosen desktop design

### DIFF
--- a/docs/ux/exploration/1-desktop-app/01-workbench.html
+++ b/docs/ux/exploration/1-desktop-app/01-workbench.html
@@ -1,0 +1,310 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Desktop — 1 · The Workbench</title>
+<style>
+  :root{
+    --bg0:#050507; --bg1:#0a1020; --panel:#0d1322; --panel2:#101830;
+    --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --text:#e8ecf6; --dim:#8b93a7; --faint:#5a627a;
+    --orange:#ffaa40; --rose:#f43f5e; --violet:#a78bfa; --blue:#5aa2ff; --green:#2ec66a;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:
+      radial-gradient(1100px 500px at 15% -10%, rgba(167,139,250,.10), transparent 60%),
+      radial-gradient(900px 500px at 90% 0%, rgba(255,170,64,.07), transparent 55%),
+      linear-gradient(160deg,var(--bg0),var(--bg1));
+    color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh; padding:48px 24px 80px;
+  }
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:680px;margin:0 auto 40px;font-size:14px}
+
+  /* ============ the window ============ */
+  .stage{position:relative;max-width:1240px;margin:0 auto}
+  .window{
+    border-radius:14px;overflow:hidden;background:linear-gradient(175deg,#0c1222,#080d1a);
+    border:1px solid var(--line2);
+    box-shadow:0 0 0 1px rgba(46,198,106,.18), 0 0 44px rgba(46,198,106,.07), 0 40px 90px rgba(0,0,0,.6);
+    display:flex;flex-direction:column;height:780px;
+  }
+  /* titlebar */
+  .titlebar{height:44px;flex:none;display:flex;align-items:center;gap:14px;padding:0 14px;
+    border-bottom:1px solid var(--line);background:rgba(255,255,255,.015)}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;background:#3a4157;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .crumbs{flex:1;display:flex;justify-content:center;align-items:center;gap:8px;font:500 12.5px var(--mono);color:var(--dim)}
+  .crumbs .dot{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
+  .crumbs b{color:var(--text);font-weight:600}
+  .crumbs .sep{color:var(--faint)}
+  .tb-actions{display:flex;gap:6px}
+  .tb-actions span{width:30px;height:26px;border-radius:7px;display:grid;place-items:center;color:var(--dim);font-size:13px;border:1px solid transparent}
+  .tb-actions span:hover{background:rgba(255,255,255,.05)}
+  .tb-actions .kbd-chip{width:auto;padding:0 8px;font:600 10.5px var(--mono);border:1px solid var(--line);color:var(--faint)}
+
+  .main{flex:1;display:flex;min-height:0}
+
+  /* ============ sidebar: streams ============ */
+  .side{width:292px;flex:none;border-right:1px solid var(--line);display:flex;flex-direction:column;background:rgba(0,0,0,.14)}
+  .side-h{padding:16px 18px 10px;display:flex;align-items:baseline;justify-content:space-between}
+  .side-h b{font:650 11px var(--mono);letter-spacing:.18em;color:var(--dim)}
+  .side-h small{font:500 11px var(--mono);color:var(--faint)}
+  .streams{flex:1;overflow:hidden;padding:2px 10px}
+  .thread{position:relative;border-radius:10px;padding:9px 12px 9px 34px;margin:2px 0;cursor:default}
+  .thread .node{position:absolute;left:13px;top:14px;width:9px;height:9px;border-radius:50%;background:var(--faint)}
+  .thread .t{font-size:13.5px;font-weight:520;color:var(--dim)}
+  .thread .meta{font:500 10.5px var(--mono);color:var(--faint);margin-top:1px}
+  .thread.active{background:linear-gradient(90deg,rgba(46,198,106,.10),rgba(46,198,106,.02));border:1px solid rgba(46,198,106,.22)}
+  .thread.active .node{background:var(--green);box-shadow:0 0 10px var(--green)}
+  .thread.active .t{color:var(--text);font-weight:600}
+  .thread.selected{outline:1px solid rgba(90,162,255,.4);background:rgba(90,162,255,.06)}
+  .badge{display:inline-block;font:600 9.5px var(--mono);letter-spacing:.08em;padding:2px 7px;border-radius:20px;vertical-align:1px;margin-left:6px}
+  .badge.paused{color:var(--orange);background:rgba(255,170,64,.1)}
+  .badge.parked{color:var(--violet);background:rgba(167,139,250,.12)}
+  .badge.done{color:var(--green);background:rgba(46,198,106,.1)}
+  /* branch rows: literal flow lines */
+  .branches{position:relative;margin:0 0 4px}
+  .branch{position:relative;padding:6px 12px 6px 52px;border-radius:8px}
+  .branch::before{content:"";position:absolute;left:17px;top:-8px;width:16px;height:24px;
+    border-left:2px solid rgba(90,162,255,.4);border-bottom:2px solid rgba(90,162,255,.4);border-bottom-left-radius:12px}
+  .branch .bnode{position:absolute;left:36px;top:13px;width:7px;height:7px;border-radius:50%;background:var(--blue)}
+  .branch .t{font-size:13px;color:var(--dim)}
+  .branch.live{background:rgba(90,162,255,.07)}
+  .branch.live::before{border-color:var(--green)}
+  .branch.live .bnode{background:var(--green);box-shadow:0 0 8px var(--green)}
+  .branch.live .t{color:var(--text);font-weight:560}
+  .branch.parked .bnode{background:var(--violet);box-shadow:none}
+  .branch.parked .t{color:var(--faint)}
+  .thread.done-t .t{color:var(--faint);text-decoration:line-through;text-decoration-color:rgba(46,198,106,.5)}
+  .thread.done-t .node{background:transparent;border:2px solid var(--green);width:7px;height:7px}
+  .side-f{flex:none;padding:12px 16px;border-top:1px solid var(--line);display:flex;gap:8px}
+  .ghost-btn{flex:1;text-align:center;font:600 12px var(--mono);color:var(--dim);border:1px dashed var(--line2);border-radius:9px;padding:8px 0}
+  .ghost-btn:hover{color:var(--text);border-color:var(--blue)}
+
+  /* ============ center: focus canvas ============ */
+  .center{flex:1;min-width:0;display:flex;flex-direction:column;padding:26px 30px 0}
+  .stack{position:relative;margin-bottom:26px}
+  .card{border-radius:14px;border:1px solid var(--line2);background:linear-gradient(165deg,#121a30,#0d1426);padding:18px 22px}
+  .card.parent{position:absolute;inset:-14px 18px auto 18px;height:60px;opacity:.55;z-index:0;
+    display:flex;align-items:flex-start;gap:10px;padding:10px 22px;border-color:var(--line)}
+  .card.parent .pt{font-size:13px;color:var(--dim);font-weight:550}
+  .card.parent .pk{font:600 9.5px var(--mono);letter-spacing:.12em;color:var(--faint);border:1px solid var(--line);
+    border-radius:5px;padding:2px 6px;margin-top:-1px}
+  .card.focus{position:relative;z-index:1;border-color:rgba(46,198,106,.35);
+    box-shadow:0 0 0 1px rgba(46,198,106,.12), 0 18px 44px rgba(0,0,0,.45)}
+  .focus-top{display:flex;align-items:flex-start;justify-content:space-between;gap:16px}
+  .focus-title{font-size:23px;font-weight:650;letter-spacing:-.01em}
+  .live-chip{display:inline-flex;align-items:center;gap:7px;font:650 10.5px var(--mono);letter-spacing:.14em;
+    color:var(--green);background:rgba(46,198,106,.1);border:1px solid rgba(46,198,106,.3);border-radius:999px;padding:5px 11px;white-space:nowrap}
+  .live-chip i{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
+  .scopes{display:flex;gap:8px;margin-top:12px;flex-wrap:wrap}
+  .scope{display:inline-flex;align-items:center;gap:6px;font:520 11.5px var(--mono);color:var(--dim);
+    background:rgba(90,162,255,.06);border:1px solid rgba(90,162,255,.16);border-radius:7px;padding:4px 9px}
+  .scope b{color:var(--blue);font-weight:600}
+  .focus-actions{display:flex;gap:10px;margin-top:18px}
+  .btn{font:600 12.5px var(--mono);border-radius:9px;padding:8px 14px;border:1px solid var(--line2);color:var(--dim);display:inline-flex;gap:8px;align-items:center}
+  .btn kbd{font:600 10px var(--mono);border:1px solid var(--line);border-radius:4px;padding:1px 5px;color:var(--faint)}
+  .btn.primary{color:#dffbe9;background:rgba(46,198,106,.14);border-color:rgba(46,198,106,.4)}
+  .btn:hover{border-color:var(--blue);color:var(--text)}
+
+  /* notes */
+  .notes-h{display:flex;align-items:baseline;justify-content:space-between;margin:2px 2px 10px}
+  .notes-h b{font:650 11px var(--mono);letter-spacing:.18em;color:var(--dim)}
+  .seg{display:flex;border:1px solid var(--line);border-radius:8px;overflow:hidden;font:600 11px var(--mono)}
+  .seg span{padding:4px 12px;color:var(--faint)}
+  .seg .on{background:rgba(90,162,255,.12);color:var(--blue)}
+  .notes{flex:1;overflow:hidden;min-height:0;padding-bottom:8px}
+  .day-sep{display:flex;align-items:center;gap:12px;font:650 10px var(--mono);letter-spacing:.2em;color:var(--faint);margin:10px 0}
+  .day-sep::before,.day-sep::after{content:"";height:1px;background:var(--line);flex:1}
+  .note{display:flex;gap:14px;padding:8px 6px;border-radius:9px}
+  .note:hover{background:rgba(255,255,255,.025)}
+  .note time{font:520 11px var(--mono);color:var(--faint);flex:none;padding-top:2px;width:42px}
+  .note .body{font-size:13.5px;color:#c7cddc}
+  .note .body .inline-scope{font:520 10.5px var(--mono);color:var(--violet);background:rgba(167,139,250,.1);
+    border-radius:5px;padding:1px 6px;margin-left:8px;white-space:nowrap}
+  .note.event .body{color:var(--faint);font:500 12px var(--mono)}
+  .note.event .body b{color:var(--blue);font-weight:600}
+
+  /* ============ today rail ============ */
+  .rail{width:64px;flex:none;border-left:1px solid var(--line);display:flex;flex-direction:column;align-items:center;padding:14px 0;background:rgba(0,0,0,.14)}
+  .rail b{font:650 9.5px var(--mono);letter-spacing:.18em;color:var(--faint);writing-mode:vertical-rl;margin-bottom:12px}
+  .rail svg{flex:1}
+  .rail .open{width:34px;height:34px;border-radius:9px;border:1px solid var(--line2);display:grid;place-items:center;color:var(--dim);font-size:15px;margin-top:10px}
+  .rail .open:hover{color:var(--blue);border-color:var(--blue)}
+
+  /* ============ capture bar ============ */
+  .capture{flex:none;padding:14px 22px 16px;border-top:1px solid var(--line);background:rgba(255,255,255,.015)}
+  .cap-box{display:flex;align-items:center;gap:12px;border:1px solid rgba(90,162,255,.3);border-radius:12px;
+    background:rgba(8,13,26,.9);padding:12px 16px;box-shadow:0 0 0 3px rgba(90,162,255,.06)}
+  .cap-box .prompt{font:700 14px var(--mono);color:var(--blue)}
+  .cap-box .ph{flex:1;font:450 13.5px var(--mono);color:var(--faint)}
+  .cap-box .ph .caret{display:inline-block;width:8px;height:16px;background:var(--blue);vertical-align:-3px;margin-right:6px;opacity:.9}
+  .cap-box .target{font:600 10.5px var(--mono);color:var(--green);background:rgba(46,198,106,.08);
+    border:1px solid rgba(46,198,106,.25);border-radius:999px;padding:4px 10px;white-space:nowrap}
+  .cap-hints{display:flex;gap:16px;margin-top:8px;padding:0 6px;font:520 11px var(--mono);color:var(--faint)}
+  .cap-hints kbd{border:1px solid var(--line);border-radius:4px;padding:0 5px;color:var(--dim)}
+
+  /* ============ annotations ============ */
+  .pin{position:absolute;z-index:5;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,var(--orange),var(--rose));color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45);cursor:default}
+  .legend{max-width:1240px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,var(--orange),var(--rose));
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1240px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}.window{height:auto;min-height:780px}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Desktop Design · Screen 1 of 4</div>
+<h1>The <span class="g">Workbench</span></h1>
+<p class="sub">The main window. Attention is drawn as a literal flow — streams on the left, the focus stack in the middle, one capture bar that speaks the same grammar as the CLI. Frameless Tauri window, custom titlebar.</p>
+
+<div class="stage">
+  <div class="pin" style="top:8px;left:50%;transform:translateX(-50%)">1</div>
+  <div class="pin" style="top:120px;left:-13px">2</div>
+  <div class="pin" style="top:96px;right:335px">3</div>
+  <div class="pin" style="top:208px;right:395px">4</div>
+  <div class="pin" style="top:420px;right:335px">5</div>
+  <div class="pin" style="top:330px;right:-13px">6</div>
+  <div class="pin" style="bottom:52px;left:50%;transform:translateX(-50%)">7</div>
+  <div class="pin" style="bottom:150px;left:-13px">8</div>
+
+  <div class="window">
+    <div class="titlebar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <div class="crumbs"><span class="dot"></span> <b>improving AIDX</b> <span class="sep">▸</span> <b>answering support</b> <span class="sep">·</span> 23m in focus</div>
+      <div class="tb-actions"><span title="Flow map">◎</span><span title="Search">⌕</span><span class="kbd-chip">⌘K</span><span title="Settings">⚙</span></div>
+    </div>
+
+    <div class="main">
+      <!-- sidebar -->
+      <div class="side">
+        <div class="side-h"><b>STREAMS</b><small>2 live · 2 paused · 1 done</small></div>
+        <div class="streams">
+          <div class="thread active">
+            <span class="node"></span>
+            <div class="t">improving AIDX</div>
+            <div class="meta">⌂ component-library · started 09:12</div>
+          </div>
+          <div class="branches">
+            <div class="branch live"><span class="bnode"></span><div class="t">answering support</div></div>
+            <div class="branch parked"><span class="bnode"></span><div class="t">reading article <span class="badge parked">PARKED</span></div></div>
+          </div>
+          <div class="thread selected">
+            <span class="node" style="background:var(--orange)"></span>
+            <div class="t">wear os sync <span class="badge paused">PAUSED 2H</span></div>
+            <div class="meta">⌂ wear-companion</div>
+          </div>
+          <div class="thread">
+            <span class="node" style="background:var(--orange)"></span>
+            <div class="t">component library docs <span class="badge paused">YESTERDAY</span></div>
+            <div class="meta">⌂ component-library</div>
+          </div>
+          <div class="thread done-t">
+            <span class="node"></span>
+            <div class="t">fix release pipeline <span class="badge done">DONE</span></div>
+            <div class="meta">archive with ⇧A</div>
+          </div>
+        </div>
+        <div class="side-f"><div class="ghost-btn">+ new thread <kbd style="border:1px solid var(--line);border-radius:4px;padding:0 4px;font-size:10px">/now</kbd></div></div>
+      </div>
+
+      <!-- center -->
+      <div class="center">
+        <div class="stack">
+          <div class="card parent"><span class="pk">THREAD</span><span class="pt">improving AIDX</span></div>
+          <div class="card focus" style="margin-top:34px">
+            <div class="focus-top">
+              <div>
+                <div class="focus-title">answering support</div>
+                <div class="scopes">
+                  <span class="scope"><b>⌂</b> component-library</span>
+                  <span class="scope"><b>⎇</b> feature/aidx</span>
+                  <span class="scope"><b>~</b> /code/component-library</span>
+                </div>
+              </div>
+              <span class="live-chip"><i></i> ACTIVE · 23M</span>
+            </div>
+            <div class="focus-actions">
+              <span class="btn primary">✓ done <kbd>d</kbd></span>
+              <span class="btn">⇤ back to thread <kbd>/back</kbd></span>
+              <span class="btn">⧉ park <kbd>p</kbd></span>
+              <span class="btn">＋ branch deeper <kbd>/branch</kbd></span>
+            </div>
+          </div>
+        </div>
+
+        <div class="notes-h"><b>NOTES &amp; TRAIL</b><div class="seg"><span class="on">this branch</span><span>whole thread</span><span>everything</span></div></div>
+        <div class="notes">
+          <div class="day-sep">TODAY</div>
+          <div class="note"><time>14:02</time><div class="body">need to check auth flow</div></div>
+          <div class="note"><time>13:47</time><div class="body">support ticket #482 — token refresh 401s after idle <span class="inline-scope">⎇ feature/aidx</span></div></div>
+          <div class="note event"><time>13:41</time><div class="body">▶ branched from <b>improving AIDX</b> — “answering support”</div></div>
+          <div class="note"><time>11:20</time><div class="body">AIDX scoring feels off for long sessions — sample rate?</div></div>
+          <div class="note event"><time>09:12</time><div class="body">● thread started via <b>flo now</b> in zsh</div></div>
+        </div>
+      </div>
+
+      <!-- today rail -->
+      <div class="rail">
+        <b>TODAY</b>
+        <svg width="40" height="430" viewBox="0 0 40 430" fill="none" aria-hidden="true">
+          <path d="M20 6 C20 60 20 90 20 120" stroke="#5aa2ff" stroke-opacity=".5" stroke-width="2.5"/>
+          <path d="M20 120 C20 150 30 160 30 190 C30 220 22 232 20 250" stroke="#a78bfa" stroke-opacity=".55" stroke-width="2"/>
+          <path d="M20 120 C20 170 20 240 20 300" stroke="#5aa2ff" stroke-opacity=".35" stroke-width="2.5" stroke-dasharray="2 5"/>
+          <path d="M20 300 C20 340 20 380 20 424" stroke="#2ec66a" stroke-opacity=".8" stroke-width="2.5"/>
+          <circle cx="20" cy="6" r="3.5" fill="#5aa2ff"/>
+          <circle cx="20" cy="76" r="2.5" fill="#8b93a7"/>
+          <circle cx="30" cy="190" r="2.5" fill="#a78bfa"/>
+          <circle cx="20" cy="300" r="3.5" fill="#2ec66a"/>
+          <circle cx="20" cy="358" r="2.5" fill="#8b93a7"/>
+          <circle cx="20" cy="424" r="4" fill="#2ec66a"/>
+          <circle cx="20" cy="424" r="8" stroke="#2ec66a" stroke-opacity=".4"/>
+        </svg>
+        <span class="open" title="Open flow map">◎</span>
+      </div>
+    </div>
+
+    <!-- capture -->
+    <div class="capture">
+      <div class="cap-box">
+        <span class="prompt">›</span>
+        <span class="ph"><span class="caret"></span>capture a thought — plain text becomes a note…</span>
+        <span class="target">→ answering support</span>
+      </div>
+      <div class="cap-hints">
+        <span><kbd>/</kbd> commands</span><span><kbd>?</kbd> hints</span><span><kbd>⌃↑↓</kbd> note history</span><span><kbd>↵</kbd> capture</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Focus breadcrumb titlebar.</b> The frameless window’s drag region doubles as a status line: live dot, thread ▸ branch, time in focus. You always know where you are, even at a glance from another monitor.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>Streams, not lists.</b> Threads render as flow lines — branches literally fork off their parent with drawn connectors. The active beam glows green; paused streams cool to amber; done items remain as tombstones until archived.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>The focus stack.</b> Cards physically stack: the parent thread peeks out behind the active branch. <i>Back</i> pops the card; <i>branch deeper</i> pushes a new one. The mental stack becomes a visible one.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>Ambient scope chips.</b> Repo, git branch and cwd are captured automatically at creation time — shown as chips, never asked for. Clicking one filters the stream list to that scope.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>Notes &amp; trail.</b> Notes interleave with system events (branched, resumed, started via CLI) in one river, filterable by branch / thread / everything. Compact mono timestamps keep it scannable.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>The Today rail.</b> A slim braid of your day — every fork, pause and capture as a vertical stream. It’s a live teaser of the full Flow Map (mock-up 4); click ◎ to expand.</p></div>
+  <div class="leg"><span class="n">7</span><p><b>One capture bar, same grammar.</b> Plain text notes the active target (shown as a green pill). <kbd>/</kbd> opens the same slash-command palette as the TUI — <i>/now, /branch, /park, /done</i>. Muscle memory transfers 1:1 from the terminal.</p></div>
+  <div class="leg"><span class="n">8</span><p><b>State as light.</b> The window ring glows softly with the state colour — green while focused, amber when everything is paused, violet when you’re parked deep in a branch. Ambient awareness without a single notification.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · TAURI DESKTOP CONCEPT — next: <a href="02-quick-capture.html">2 · Quick Capture</a> · <a href="03-companion.html">3 · Companion &amp; Tray</a> · <a href="04-flow-map.html">4 · Flow Map</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/1-desktop-app/01-workbench.html
+++ b/docs/ux/exploration/1-desktop-app/01-workbench.html
@@ -38,9 +38,13 @@
   /* titlebar */
   .titlebar{height:44px;flex:none;display:flex;align-items:center;gap:14px;padding:0 14px;
     border-bottom:1px solid var(--line);background:rgba(255,255,255,.015)}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;background:#3a4157;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .wordmark{font:800 13.5px var(--mono);background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent;white-space:nowrap}
+  .switcher{display:flex;align-items:center;background:rgba(255,255,255,.05);border-radius:14px;padding:3px;font:600 11px var(--mono);white-space:nowrap}
+  .switcher span{padding:4px 12px;border-radius:11px;color:var(--faint)}
+  .switcher .on{background:rgba(255,255,255,.11);color:var(--text);font-weight:700}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .crumbs{flex:1;display:flex;justify-content:center;align-items:center;gap:8px;font:500 12.5px var(--mono);color:var(--dim)}
   .crumbs .dot{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
   .crumbs b{color:var(--text);font-weight:600}
@@ -185,9 +189,11 @@
 
   <div class="window">
     <div class="titlebar">
-      <div class="lights"><i></i><i></i><i></i></div>
+      <span class="wordmark">≋ Flow</span>
+      <div class="switcher"><span class="on">◨ Workbench</span><span>◎ Flow Map</span></div>
       <div class="crumbs"><span class="dot"></span> <b>improving AIDX</b> <span class="sep">▸</span> <b>answering support</b> <span class="sep">·</span> 23m in focus</div>
-      <div class="tb-actions"><span title="Flow map">◎</span><span title="Search">⌕</span><span class="kbd-chip">⌘K</span><span title="Settings">⚙</span></div>
+      <div class="tb-actions"><span class="kbd-chip">Ctrl+K</span><span title="Settings">⚙</span></div>
+      <div class="lights"><i></i><i></i><i></i></div>
     </div>
 
     <div class="main">
@@ -287,7 +293,7 @@
         <span class="target">→ answering support</span>
       </div>
       <div class="cap-hints">
-        <span><kbd>/</kbd> commands</span><span><kbd>?</kbd> hints</span><span><kbd>⌃↑↓</kbd> note history</span><span><kbd>↵</kbd> capture</span>
+        <span><kbd>/</kbd> commands</span><span><kbd>?</kbd> hints</span><span><kbd>Ctrl+↑↓</kbd> note history</span><span><kbd>↵</kbd> capture</span>
       </div>
     </div>
   </div>

--- a/docs/ux/exploration/1-desktop-app/02-quick-capture.html
+++ b/docs/ux/exploration/1-desktop-app/02-quick-capture.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Desktop — 2 · Quick Capture</title>
+<style>
+  :root{
+    --bg0:#050507; --bg1:#0a1020; --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --text:#e8ecf6; --dim:#8b93a7; --faint:#5a627a;
+    --orange:#ffaa40; --rose:#f43f5e; --violet:#a78bfa; --blue:#5aa2ff; --green:#2ec66a;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:
+      radial-gradient(1100px 500px at 15% -10%, rgba(167,139,250,.10), transparent 60%),
+      radial-gradient(900px 500px at 90% 0%, rgba(255,170,64,.07), transparent 55%),
+      linear-gradient(160deg,var(--bg0),var(--bg1));
+    color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px;
+  }
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:700px;margin:0 auto 40px;font-size:14px}
+
+  /* fake desktop behind the palette */
+  .desk{position:relative;max-width:1100px;margin:0 auto;height:640px;border-radius:16px;overflow:hidden;
+    border:1px solid var(--line2);
+    background:linear-gradient(200deg,#141a2e,#0a0e1c 55%,#120f22);
+    box-shadow:0 40px 90px rgba(0,0,0,.55)}
+  .fake{position:absolute;border-radius:10px;background:rgba(255,255,255,.035);border:1px solid rgba(255,255,255,.05);filter:blur(1.5px)}
+  .fake .bar{height:26px;border-bottom:1px solid rgba(255,255,255,.05);background:rgba(255,255,255,.03);border-radius:10px 10px 0 0}
+  .fake .l{height:8px;border-radius:4px;background:rgba(255,255,255,.05);margin:12px 16px}
+  .dim-veil{position:absolute;inset:0;background:rgba(4,6,12,.55);backdrop-filter:blur(2px)}
+
+  /* the palette */
+  .palette{position:absolute;left:50%;top:88px;transform:translateX(-50%);width:640px;border-radius:16px;
+    background:rgba(11,16,30,.92);border:1px solid rgba(90,162,255,.28);
+    box-shadow:0 0 0 1px rgba(90,162,255,.1), 0 30px 80px rgba(0,0,0,.7), 0 0 60px rgba(90,162,255,.08);
+    overflow:hidden}
+  .pal-ctx{display:flex;align-items:center;gap:10px;padding:11px 16px;border-bottom:1px solid var(--line);
+    font:520 11.5px var(--mono);color:var(--dim);background:rgba(255,255,255,.02)}
+  .pal-ctx .dot{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
+  .pal-ctx b{color:var(--text);font-weight:600}
+  .pal-ctx .scope{margin-left:auto;color:var(--faint)}
+  .pal-in{display:flex;align-items:center;gap:12px;padding:16px 18px;font:450 16px var(--mono)}
+  .pal-in .prompt{color:var(--blue);font-weight:700}
+  .pal-in .typed{color:var(--text)}
+  .pal-in .caret{display:inline-block;width:9px;height:20px;background:var(--blue);vertical-align:-4px;margin-left:2px}
+  .cmds{border-top:1px solid var(--line);padding:6px}
+  .cmd{display:flex;align-items:center;gap:14px;padding:10px 14px;border-radius:10px}
+  .cmd .k{font:650 13px var(--mono);color:var(--blue);width:86px}
+  .cmd .d{flex:1;font-size:12.5px;color:var(--dim)}
+  .cmd .tgt{font:600 9.5px var(--mono);letter-spacing:.1em;color:var(--faint);border:1px solid var(--line);border-radius:5px;padding:2px 7px}
+  .cmd.sel{background:rgba(90,162,255,.12);outline:1px solid rgba(90,162,255,.35)}
+  .cmd.sel .d{color:#c7cddc}
+  .pal-foot{display:flex;gap:18px;padding:10px 16px;border-top:1px solid var(--line);
+    font:520 11px var(--mono);color:var(--faint);background:rgba(255,255,255,.015)}
+  .pal-foot kbd{border:1px solid var(--line);border-radius:4px;padding:0 5px;color:var(--dim)}
+  .pal-foot .r{margin-left:auto}
+
+  /* second, note-state palette */
+  .palette.note-state{top:434px;width:560px;border-color:rgba(46,198,106,.3);
+    box-shadow:0 0 0 1px rgba(46,198,106,.1), 0 30px 80px rgba(0,0,0,.7), 0 0 50px rgba(46,198,106,.07)}
+  .palette.note-state .pal-in{font-size:15px}
+  .ghost{color:var(--faint)}
+
+  .pin{position:absolute;z-index:5;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,var(--orange),var(--rose));color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+  .stage{position:relative;max-width:1100px;margin:0 auto}
+
+  .legend{max-width:1100px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,var(--orange),var(--rose));
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1100px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Desktop Design · Screen 2 of 4</div>
+<h1>Quick <span class="g">Capture</span></h1>
+<p class="sub">Summoned from anywhere with a global shortcut (<b style="color:var(--text)">⌥ Space</b>) — a transparent, frameless Tauri window that floats over whatever you’re doing. Type, hit ↵, it’s gone. Your editor never loses focus for more than a breath.</p>
+
+<div class="stage">
+  <div class="pin" style="top:74px;left:170px">1</div>
+  <div class="pin" style="top:196px;right:180px">2</div>
+  <div class="pin" style="top:300px;left:190px">3</div>
+  <div class="pin" style="top:508px;right:218px">4</div>
+
+  <div class="desk">
+    <!-- blurred fake windows to suggest "over your work" -->
+    <div class="fake" style="left:36px;top:40px;width:520px;height:420px"><div class="bar"></div><div class="l" style="width:60%"></div><div class="l" style="width:80%"></div><div class="l" style="width:45%"></div><div class="l" style="width:70%"></div><div class="l" style="width:55%"></div></div>
+    <div class="fake" style="right:48px;top:110px;width:440px;height:460px"><div class="bar"></div><div class="l" style="width:70%"></div><div class="l" style="width:50%"></div><div class="l" style="width:85%"></div></div>
+    <div class="dim-veil"></div>
+
+    <!-- state A: slash palette -->
+    <div class="palette">
+      <div class="pal-ctx"><span class="dot"></span> capturing to <b>answering support</b> <span style="color:var(--faint)">· improving AIDX</span><span class="scope">⌂ component-library · ⎇ feature/aidx</span></div>
+      <div class="pal-in"><span class="prompt">›</span><span class="typed">/par</span><span class="caret"></span></div>
+      <div class="cmds">
+        <div class="cmd sel"><span class="k">/park</span><span class="d">park the active branch — keep it warm, drop it from focus</span><span class="tgt">BRANCH</span></div>
+        <div class="cmd"><span class="k">/pause</span><span class="d">pause the current thread with an optional note</span><span class="tgt">THREAD</span></div>
+        <div class="cmd"><span class="k">/back</span><span class="d">return to the parent thread, parking active branches</span><span class="tgt">STACK</span></div>
+      </div>
+      <div class="pal-foot"><span><kbd>↑↓</kbd> choose</span><span><kbd>⇥</kbd> complete</span><span><kbd>↵</kbd> run</span><span><kbd>esc</kbd> vanish</span><span class="r"><kbd>⌘↵</kbd> run &amp; open workbench</span></div>
+    </div>
+
+    <!-- state B: plain note -->
+    <div class="palette note-state">
+      <div class="pal-in"><span class="prompt" style="color:var(--green)">›</span><span class="typed">rate limiter also needs the retry-after header</span><span class="caret" style="background:var(--green)"></span></div>
+      <div class="pal-foot"><span style="color:var(--green)">↵ note → <b style="color:#dffbe9">answering support</b></span><span class="r ghost">no window switch · you never left your editor</span></div>
+    </div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Context header, zero questions.</b> The palette opens already knowing the active capture target and its scopes, read straight from the shared SQLite store. You see <i>where the thought will land</i> before you type it.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>The exact TUI command palette.</b> Type <kbd>/</kbd> and the same fuzzy-filtered slash commands appear, name-matches ranked above description matches — <i>/par</i> prefers <i>/park</i> over <i>/back</i>. One grammar across CLI, TUI and desktop.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Escape hatches, not workflows.</b> <kbd>↵</kbd> runs and the window evaporates; <kbd>⌘↵</kbd> runs <i>and</i> raises the Workbench for when a quick thought turns into a context switch you actually want.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>Plain text is a note. Always.</b> No mode to remember: anything without a slash is captured to the active branch, timestamped, done. Median time from shortcut to back-in-editor: about two seconds.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · TAURI DESKTOP CONCEPT — <a href="01-workbench.html">1 · Workbench</a> · next: <a href="03-companion.html">3 · Companion &amp; Tray</a> · <a href="04-flow-map.html">4 · Flow Map</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/1-desktop-app/02-quick-capture.html
+++ b/docs/ux/exploration/1-desktop-app/02-quick-capture.html
@@ -88,7 +88,7 @@
 
 <div class="kicker">Liminal Flow · Desktop Design · Screen 2 of 4</div>
 <h1>Quick <span class="g">Capture</span></h1>
-<p class="sub">Summoned from anywhere with a global shortcut (<b style="color:var(--text)">⌥ Space</b>) — a transparent, frameless Tauri window that floats over whatever you’re doing. Type, hit ↵, it’s gone. Your editor never loses focus for more than a breath.</p>
+<p class="sub">Summoned from anywhere with a global shortcut (<b style="color:var(--text)">Super+Space</b>) — a transparent, frameless Tauri window that floats over whatever you’re doing. Type, hit ↵, it’s gone. Your editor never loses focus for more than a breath.</p>
 
 <div class="stage">
   <div class="pin" style="top:74px;left:170px">1</div>
@@ -111,7 +111,7 @@
         <div class="cmd"><span class="k">/pause</span><span class="d">pause the current thread with an optional note</span><span class="tgt">THREAD</span></div>
         <div class="cmd"><span class="k">/back</span><span class="d">return to the parent thread, parking active branches</span><span class="tgt">STACK</span></div>
       </div>
-      <div class="pal-foot"><span><kbd>↑↓</kbd> choose</span><span><kbd>⇥</kbd> complete</span><span><kbd>↵</kbd> run</span><span><kbd>esc</kbd> vanish</span><span class="r"><kbd>⌘↵</kbd> run &amp; open workbench</span></div>
+      <div class="pal-foot"><span><kbd>↑↓</kbd> choose</span><span><kbd>⇥</kbd> complete</span><span><kbd>↵</kbd> run</span><span><kbd>esc</kbd> vanish</span><span class="r"><kbd>Ctrl+↵</kbd> run &amp; open workbench</span></div>
     </div>
 
     <!-- state B: plain note -->
@@ -125,7 +125,7 @@
 <div class="legend">
   <div class="leg"><span class="n">1</span><p><b>Context header, zero questions.</b> The palette opens already knowing the active capture target and its scopes, read straight from the shared SQLite store. You see <i>where the thought will land</i> before you type it.</p></div>
   <div class="leg"><span class="n">2</span><p><b>The exact TUI command palette.</b> Type <kbd>/</kbd> and the same fuzzy-filtered slash commands appear, name-matches ranked above description matches — <i>/par</i> prefers <i>/park</i> over <i>/back</i>. One grammar across CLI, TUI and desktop.</p></div>
-  <div class="leg"><span class="n">3</span><p><b>Escape hatches, not workflows.</b> <kbd>↵</kbd> runs and the window evaporates; <kbd>⌘↵</kbd> runs <i>and</i> raises the Workbench for when a quick thought turns into a context switch you actually want.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Escape hatches, not workflows.</b> <kbd>↵</kbd> runs and the window evaporates; <kbd>Ctrl+↵</kbd> runs <i>and</i> raises the Workbench for when a quick thought turns into a context switch you actually want.</p></div>
   <div class="leg"><span class="n">4</span><p><b>Plain text is a note. Always.</b> No mode to remember: anything without a slash is captured to the active branch, timestamped, done. Median time from shortcut to back-in-editor: about two seconds.</p></div>
 </div>
 

--- a/docs/ux/exploration/1-desktop-app/03-companion.html
+++ b/docs/ux/exploration/1-desktop-app/03-companion.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Desktop — 3 · Companion &amp; Tray</title>
+<style>
+  :root{
+    --bg0:#050507; --bg1:#0a1020; --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --text:#e8ecf6; --dim:#8b93a7; --faint:#5a627a;
+    --orange:#ffaa40; --rose:#f43f5e; --violet:#a78bfa; --blue:#5aa2ff; --green:#2ec66a;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:
+      radial-gradient(1100px 500px at 15% -10%, rgba(167,139,250,.10), transparent 60%),
+      radial-gradient(900px 500px at 90% 0%, rgba(255,170,64,.07), transparent 55%),
+      linear-gradient(160deg,var(--bg0),var(--bg1));
+    color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px;
+  }
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:720px;margin:0 auto 40px;font-size:14px}
+
+  .desk{position:relative;max-width:1100px;margin:0 auto;height:660px;border-radius:16px;overflow:hidden;
+    border:1px solid var(--line2);
+    background:linear-gradient(200deg,#131a2d,#0a0e1c 55%,#110f21);
+    box-shadow:0 40px 90px rgba(0,0,0,.55)}
+  .menubar{position:absolute;top:0;left:0;right:0;height:30px;background:rgba(10,14,26,.85);
+    border-bottom:1px solid var(--line);display:flex;align-items:center;padding:0 14px;gap:18px;
+    font:520 11.5px var(--mono);color:var(--faint)}
+  .menubar .right{margin-left:auto;display:flex;gap:16px;align-items:center}
+  .menubar .tray-ic{color:var(--green);font-weight:700;background:rgba(46,198,106,.12);border-radius:5px;padding:1px 7px}
+  .fake{position:absolute;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05);filter:blur(1px)}
+  .fake .bar{height:24px;border-bottom:1px solid rgba(255,255,255,.05);background:rgba(255,255,255,.03);border-radius:10px 10px 0 0}
+  .fake .l{height:8px;border-radius:4px;background:rgba(255,255,255,.05);margin:12px 16px}
+
+  /* ---- collapsed pill ---- */
+  .pill{position:absolute;left:56px;top:64px;display:inline-flex;align-items:center;gap:10px;
+    background:rgba(10,15,28,.94);border:1px solid rgba(46,198,106,.35);border-radius:999px;padding:9px 16px 9px 12px;
+    box-shadow:0 8px 30px rgba(0,0,0,.55), 0 0 24px rgba(46,198,106,.10);font:560 12.5px var(--mono)}
+  .pill .dot{width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
+  .pill .depth{display:flex;gap:3px}
+  .pill .depth i{width:4px;height:4px;border-radius:50%;background:var(--blue);opacity:.9}
+  .pill .depth i:first-child{background:var(--dim)}
+  .pill .t{color:var(--text)}
+  .pill time{color:var(--faint);font-weight:500}
+
+  /* ---- expanded pill (hover state) ---- */
+  .pill-x{position:absolute;left:56px;top:130px;width:300px;background:rgba(10,15,28,.96);
+    border:1px solid rgba(46,198,106,.3);border-radius:16px;padding:14px 16px;
+    box-shadow:0 16px 44px rgba(0,0,0,.6), 0 0 30px rgba(46,198,106,.08)}
+  .pill-x .row1{display:flex;align-items:center;gap:9px;font:560 12.5px var(--mono)}
+  .pill-x .row1 .dot{width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
+  .pill-x .row1 time{margin-left:auto;color:var(--faint);font-weight:500}
+  .pill-x .stackline{font:500 11px var(--mono);color:var(--faint);margin:7px 0 12px;padding-left:17px}
+  .pill-x .stackline b{color:var(--dim);font-weight:560}
+  .pill-x .acts{display:flex;gap:7px}
+  .pill-x .a{flex:1;text-align:center;font:620 11px var(--mono);color:var(--dim);border:1px solid var(--line2);
+    border-radius:8px;padding:7px 0}
+  .pill-x .a.g{color:#dffbe9;background:rgba(46,198,106,.13);border-color:rgba(46,198,106,.35)}
+  .pill-x .a:hover{color:var(--text);border-color:var(--blue)}
+  .drag-hint{position:absolute;left:372px;top:150px;font:500 11px var(--mono);color:var(--faint);width:150px}
+  .drag-hint::before{content:"⟵";margin-right:6px;color:var(--dim)}
+
+  /* ---- tray flyout ---- */
+  .tray{position:absolute;right:40px;top:38px;width:308px;background:rgba(10,15,28,.97);
+    border:1px solid var(--line2);border-radius:14px;overflow:hidden;
+    box-shadow:0 20px 50px rgba(0,0,0,.65)}
+  .tray .sec{padding:12px 14px;border-bottom:1px solid var(--line)}
+  .tray .cap{font:650 9.5px var(--mono);letter-spacing:.18em;color:var(--faint);margin-bottom:8px}
+  .tray .now{display:flex;align-items:center;gap:9px;font-size:13.5px;font-weight:560}
+  .tray .now .dot{width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
+  .tray .now time{margin-left:auto;font:500 11px var(--mono);color:var(--faint)}
+  .tray .sub2{font:500 11px var(--mono);color:var(--faint);padding-left:17px;margin-top:2px}
+  .tray .item{display:flex;align-items:center;gap:9px;padding:7px 8px;border-radius:8px;font-size:13px;color:var(--dim)}
+  .tray .item:hover{background:rgba(90,162,255,.08);color:var(--text)}
+  .tray .item .st{width:7px;height:7px;border-radius:50%;flex:none}
+  .tray .item kbd{margin-left:auto;font:600 10px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:4px;padding:0 5px}
+  .tray .row-acts{display:flex;gap:7px;padding:10px 12px}
+  .tray .row-acts .a{flex:1;text-align:center;font:620 11px var(--mono);color:var(--dim);border:1px solid var(--line2);border-radius:8px;padding:7px 0}
+  .tray .row-acts .a:hover{color:var(--text);border-color:var(--blue)}
+
+  /* ---- welcome back card ---- */
+  .wb{position:absolute;left:50%;bottom:52px;transform:translateX(-50%);width:520px;
+    background:rgba(11,16,30,.97);border:1px solid rgba(255,170,64,.35);border-radius:16px;padding:18px 20px;
+    box-shadow:0 24px 60px rgba(0,0,0,.65), 0 0 40px rgba(255,170,64,.07)}
+  .wb .cap{font:650 9.5px var(--mono);letter-spacing:.18em;color:var(--orange);margin-bottom:8px}
+  .wb h3{font-size:16px;font-weight:640;margin-bottom:4px}
+  .wb p{font-size:12.5px;color:var(--dim)}
+  .wb .last{margin:12px 0;padding:10px 12px;border-left:2px solid var(--blue);background:rgba(90,162,255,.05);
+    border-radius:0 8px 8px 0;font:450 12.5px var(--mono);color:#c7cddc}
+  .wb .last time{color:var(--faint)}
+  .wb .acts{display:flex;gap:8px;margin-top:12px}
+  .wb .a{font:620 12px var(--mono);border-radius:9px;padding:8px 14px;border:1px solid var(--line2);color:var(--dim)}
+  .wb .a.g{color:#dffbe9;background:rgba(46,198,106,.13);border-color:rgba(46,198,106,.4)}
+  .wb .a.ghosty{border-style:dashed}
+
+  .pin{position:absolute;z-index:6;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,var(--orange),var(--rose));color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+  .stage{position:relative;max-width:1100px;margin:0 auto}
+
+  .legend{max-width:1100px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,var(--orange),var(--rose));
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1100px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Desktop Design · Screen 3 of 4</div>
+<h1>The <span class="g">Companion</span> &amp; Tray</h1>
+<p class="sub">Flow’s whole job is ambient awareness — so most days you never open the Workbench at all. A tiny always-on-top pill and a tray menu carry the current focus with you, and a gentle “welcome back” card catches you when you drift.</p>
+
+<div class="stage">
+  <div class="pin" style="top:52px;left:20px">1</div>
+  <div class="pin" style="top:168px;left:20px">2</div>
+  <div class="pin" style="top:26px;right:16px">3</div>
+  <div class="pin" style="bottom:150px;left:230px">4</div>
+
+  <div class="desk">
+    <div class="menubar">
+      <span>File</span><span>Edit</span><span>View</span>
+      <div class="right"><span class="tray-ic">≋ flo</span><span>14:26</span></div>
+    </div>
+    <div class="fake" style="left:120px;top:210px;width:480px;height:400px"><div class="bar"></div><div class="l" style="width:65%"></div><div class="l" style="width:80%"></div><div class="l" style="width:50%"></div></div>
+    <div class="fake" style="right:120px;top:330px;width:380px;height:290px"><div class="bar"></div><div class="l" style="width:70%"></div><div class="l" style="width:45%"></div></div>
+
+    <!-- 1: collapsed pill -->
+    <div class="pill">
+      <span class="dot"></span>
+      <span class="depth"><i></i><i></i></span>
+      <span class="t">answering support</span>
+      <time>23m</time>
+    </div>
+
+    <!-- 2: expanded on hover -->
+    <div class="pill-x">
+      <div class="row1"><span class="dot"></span><span>answering support</span><time>23m</time></div>
+      <div class="stackline">↳ in <b>improving AIDX</b> · ⌂ component-library</div>
+      <div class="acts">
+        <span class="a g">✓ done</span><span class="a">⧉ park</span><span class="a">⇤ back</span><span class="a">◨ open</span>
+      </div>
+    </div>
+    <div class="drag-hint">frameless, draggable, remembers its corner</div>
+
+    <!-- 3: tray flyout -->
+    <div class="tray">
+      <div class="sec">
+        <div class="cap">NOW</div>
+        <div class="now"><span class="dot"></span> answering support <time>23m</time></div>
+        <div class="sub2">↳ improving AIDX · ⎇ feature/aidx</div>
+      </div>
+      <div class="sec">
+        <div class="cap">RESUME — RECENT STREAMS</div>
+        <div class="item"><span class="st" style="background:var(--violet)"></span> reading article <kbd>parked</kbd></div>
+        <div class="item"><span class="st" style="background:var(--orange)"></span> wear os sync <kbd>2h</kbd></div>
+        <div class="item"><span class="st" style="background:var(--orange)"></span> component library docs <kbd>1d</kbd></div>
+      </div>
+      <div class="row-acts">
+        <span class="a">› quick capture ⌥␣</span><span class="a">⏸ pause all</span><span class="a">◨ workbench</span>
+      </div>
+    </div>
+
+    <!-- 4: welcome back -->
+    <div class="wb">
+      <div class="cap">WELCOME BACK · AWAY 25 MIN</div>
+      <h3>Where were you?</h3>
+      <p>You were 23 minutes into <b style="color:var(--text)">answering support</b>, branched off <i>improving AIDX</i>. Your last thought:</p>
+      <div class="last">“need to check auth flow” <time>— 14:02, on ⎇ feature/aidx</time></div>
+      <div class="acts">
+        <span class="a g">↻ resume where I left off</span>
+        <span class="a">⏸ actually, pause it</span>
+        <span class="a ghosty">✕ dismiss</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>The pill.</b> A 30-pt always-on-top sliver: state dot, stack-depth dots (thread ▸ branch), title, time in focus. It answers “what am I supposed to be doing?” without a single click — the desktop equivalent of a shell prompt segment.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>Hover to act.</b> The pill blooms into its four verbs — done, park, back, open. Every state change here is just a CLI command under the hood, written to the shared SQLite store; the TUI in your terminal sees it within 250 ms.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Tray as resume menu.</b> The tray icon carries the state colour. Its flyout shows the live stack plus the three most recently paused/parked streams — one click on <i>wear os sync</i> runs the same logic as <kbd>r</kbd> in the TUI: activate, auto-pause the rest.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>The welcome-back card.</b> After system idle/unlock (Tauri can watch both), Flow doesn’t nag — it offers. Your last note is the memory jog; one key resumes, one key pauses honestly. Drift becomes data instead of guilt.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · TAURI DESKTOP CONCEPT — <a href="01-workbench.html">1 · Workbench</a> · <a href="02-quick-capture.html">2 · Quick Capture</a> · next: <a href="04-flow-map.html">4 · Flow Map</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/1-desktop-app/03-companion.html
+++ b/docs/ux/exploration/1-desktop-app/03-companion.html
@@ -34,6 +34,7 @@
     border-bottom:1px solid var(--line);display:flex;align-items:center;padding:0 14px;gap:18px;
     font:520 11.5px var(--mono);color:var(--faint)}
   .menubar .right{margin-left:auto;display:flex;gap:16px;align-items:center}
+  .menubar .clock{position:absolute;left:50%;transform:translateX(-50%);background:rgba(255,255,255,.06);border-radius:9px;padding:1px 10px;color:#c8cdd8}
   .menubar .tray-ic{color:var(--green);font-weight:700;background:rgba(46,198,106,.12);border-radius:5px;padding:1px 7px}
   .fake{position:absolute;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.05);filter:blur(1px)}
   .fake .bar{height:24px;border-bottom:1px solid rgba(255,255,255,.05);background:rgba(255,255,255,.03);border-radius:10px 10px 0 0}
@@ -130,8 +131,9 @@
 
   <div class="desk">
     <div class="menubar">
-      <span>File</span><span>Edit</span><span>View</span>
-      <div class="right"><span class="tray-ic">≋ flo</span><span>14:26</span></div>
+      <span>Activities</span>
+      <span class="clock">Aug 14  14:26</span>
+      <div class="right"><span class="tray-ic">≋ flo</span><span>🔊 ⚡ ▾</span></div>
     </div>
     <div class="fake" style="left:120px;top:210px;width:480px;height:400px"><div class="bar"></div><div class="l" style="width:65%"></div><div class="l" style="width:80%"></div><div class="l" style="width:50%"></div></div>
     <div class="fake" style="right:120px;top:330px;width:380px;height:290px"><div class="bar"></div><div class="l" style="width:70%"></div><div class="l" style="width:45%"></div></div>
@@ -168,7 +170,7 @@
         <div class="item"><span class="st" style="background:var(--orange)"></span> component library docs <kbd>1d</kbd></div>
       </div>
       <div class="row-acts">
-        <span class="a">› quick capture ⌥␣</span><span class="a">⏸ pause all</span><span class="a">◨ workbench</span>
+        <span class="a">› capture Super+␣</span><span class="a">⏸ pause all</span><span class="a">◨ workbench</span>
       </div>
     </div>
 

--- a/docs/ux/exploration/1-desktop-app/04-flow-map.html
+++ b/docs/ux/exploration/1-desktop-app/04-flow-map.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Desktop — 4 · The Flow Map</title>
+<style>
+  :root{
+    --bg0:#050507; --bg1:#0a1020; --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --text:#e8ecf6; --dim:#8b93a7; --faint:#5a627a;
+    --orange:#ffaa40; --rose:#f43f5e; --violet:#a78bfa; --blue:#5aa2ff; --green:#2ec66a;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:
+      radial-gradient(1100px 500px at 15% -10%, rgba(167,139,250,.10), transparent 60%),
+      radial-gradient(900px 500px at 90% 0%, rgba(255,170,64,.07), transparent 55%),
+      linear-gradient(160deg,var(--bg0),var(--bg1));
+    color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px;
+  }
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:720px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:1240px;margin:0 auto}
+  .window{border-radius:14px;overflow:hidden;background:linear-gradient(175deg,#0c1222,#080d1a);
+    border:1px solid var(--line2);
+    box-shadow:0 0 0 1px rgba(90,162,255,.12), 0 40px 90px rgba(0,0,0,.6);
+    display:flex;flex-direction:column}
+  .titlebar{height:44px;flex:none;display:flex;align-items:center;gap:14px;padding:0 14px;
+    border-bottom:1px solid var(--line);background:rgba(255,255,255,.015)}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .tb-title{flex:1;text-align:center;font:560 12.5px var(--mono);color:var(--dim)}
+  .tb-title b{color:var(--text)}
+  .tb-close{font:600 11px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:6px;padding:3px 9px}
+
+  .map-h{display:flex;align-items:center;gap:14px;padding:18px 26px 6px}
+  .date-pick{display:inline-flex;align-items:center;gap:10px;font:620 14px var(--mono);border:1px solid var(--line2);
+    border-radius:10px;padding:8px 14px}
+  .date-pick .arr{color:var(--faint)}
+  .stats{display:flex;gap:8px;margin-left:auto;flex-wrap:wrap}
+  .stat{font:560 11px var(--mono);color:var(--dim);border:1px solid var(--line);border-radius:999px;padding:5px 11px}
+  .stat b{color:var(--text);font-weight:650}
+  .stat.hero{color:#dffbe9;border-color:rgba(46,198,106,.35);background:rgba(46,198,106,.08)}
+
+  .map-wrap{position:relative;padding:6px 10px 4px}
+  .lane-label{position:absolute;font:560 11.5px var(--mono);color:var(--dim);left:26px}
+  .lane-label small{display:block;font-weight:500;font-size:10px;color:var(--faint)}
+  .lane-label.b{padding-left:12px;color:var(--faint)}
+
+  .tip{position:absolute;left:788px;top:118px;width:230px;background:rgba(11,16,30,.97);
+    border:1px solid rgba(46,198,106,.35);border-radius:10px;padding:10px 12px;z-index:4;
+    box-shadow:0 14px 34px rgba(0,0,0,.6)}
+  .tip .t{font:450 12.5px var(--mono);color:#c7cddc}
+  .tip .m{font:500 10.5px var(--mono);color:var(--faint);margin-top:5px}
+  .tip::after{content:"";position:absolute;left:24px;bottom:-6px;width:10px;height:10px;background:rgba(11,16,30,.97);
+    border-right:1px solid rgba(46,198,106,.35);border-bottom:1px solid rgba(46,198,106,.35);transform:rotate(45deg)}
+
+  .insight{display:flex;gap:10px;padding:10px 26px 20px;flex-wrap:wrap}
+  .ins{flex:1;min-width:240px;border:1px solid var(--line);border-radius:12px;padding:12px 16px;background:rgba(255,255,255,.015)}
+  .ins .cap{font:650 9.5px var(--mono);letter-spacing:.16em;color:var(--faint);margin-bottom:4px}
+  .ins .v{font-size:13.5px;color:#c7cddc}
+  .ins .v b{color:var(--text)}
+  .ins .v i{color:var(--dim)}
+
+  .pin{position:absolute;z-index:6;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,var(--orange),var(--rose));color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+
+  .legend{max-width:1240px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,var(--orange),var(--rose));
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1240px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Desktop Design · Screen 4 of 4</div>
+<h1>The <span class="g">Flow Map</span></h1>
+<p class="sub">Your attention, replayed as a braided river. Flow already records every state change as an immutable event — the map simply draws that ledger. Nothing to fill in, nothing to track. It was always there.</p>
+
+<div class="stage">
+  <div class="pin" style="top:104px;left:-13px">1</div>
+  <div class="pin" style="top:214px;left:585px">2</div>
+  <div class="pin" style="top:96px;right:280px">3</div>
+  <div class="pin" style="top:322px;left:415px">4</div>
+  <div class="pin" style="top:60px;left:190px">5</div>
+  <div class="pin" style="top:250px;right:-13px">6</div>
+
+  <div class="window">
+    <div class="titlebar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <div class="tb-title">◎ flow map — <b>where your attention actually went</b></div>
+      <span class="tb-close">esc ✕</span>
+    </div>
+
+    <div class="map-h">
+      <div class="date-pick"><span class="arr">‹</span> Today · Thu Aug 14 <span class="arr">›</span> <span style="color:var(--faint);font-size:11px">▾ week</span></div>
+      <div class="stats">
+        <span class="stat"><b>3</b> threads</span>
+        <span class="stat"><b>3</b> branches</span>
+        <span class="stat"><b>26</b> captures</span>
+        <span class="stat"><b>3</b> switches</span>
+        <span class="stat hero">longest focus <b>1h 12m</b></span>
+      </div>
+    </div>
+
+    <div class="map-wrap">
+      <div class="lane-label" style="top:96px">improving AIDX<small>⌂ component-library</small></div>
+      <div class="lane-label b" style="top:168px">↳ branches</div>
+      <div class="lane-label" style="top:238px">wear os sync<small>⌂ wear-companion</small></div>
+      <div class="lane-label" style="top:308px">fix release pipeline<small>✓ done 09:50</small></div>
+
+      <!-- tooltip on a capture dot -->
+      <div class="tip">
+        <div class="t">“need to check auth flow”</div>
+        <div class="m">14:02 · answering support · ⎇ feature/aidx</div>
+      </div>
+
+      <svg viewBox="0 0 1218 400" width="100%" aria-label="Braided timeline of today's attention">
+        <defs>
+          <linearGradient id="gsup" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#5aa2ff"/><stop offset="100%" stop-color="#2ec66a"/>
+          </linearGradient>
+          <filter id="soft" x="-40%" y="-40%" width="180%" height="180%">
+            <feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+          </filter>
+        </defs>
+
+        <!-- hour grid -->
+        <g stroke="rgba(255,255,255,.05)" stroke-width="1">
+          <line x1="263" y1="30" x2="263" y2="352"/><line x1="437" y1="30" x2="437" y2="352"/>
+          <line x1="610" y1="30" x2="610" y2="352"/><line x1="783" y1="30" x2="783" y2="352"/>
+          <line x1="957" y1="30" x2="957" y2="352"/>
+        </g>
+        <g font-family="ui-monospace,Menlo,monospace" font-size="10.5" fill="#5a627a">
+          <text x="90" y="376">09:00</text><text x="245" y="376">10:00</text><text x="419" y="376">11:00</text>
+          <text x="592" y="376">12:00</text><text x="765" y="376">13:00</text><text x="939" y="376">14:00</text>
+        </g>
+
+        <!-- fix release pipeline: 09:00–09:50, done -->
+        <path d="M90 330 L235 330" stroke="#5aa2ff" stroke-opacity=".55" stroke-width="4" stroke-linecap="round"/>
+        <circle cx="235" cy="330" r="7" fill="none" stroke="#2ec66a" stroke-width="2.5"/>
+        <path d="M231.5 330 l2.5 2.5 l5 -5" stroke="#2ec66a" stroke-width="2" fill="none"/>
+
+        <!-- improving AIDX main stream -->
+        <path d="M125 120 L379 120" stroke="#5aa2ff" stroke-width="5" stroke-linecap="round" stroke-opacity=".85"/>
+        <!-- pause: honest dashed gap while wear os takes over -->
+        <path d="M379 120 L452 120" stroke="#5aa2ff" stroke-width="2.5" stroke-dasharray="2 7" stroke-opacity=".45" stroke-linecap="round"/>
+        <path d="M452 120 L901 120" stroke="#5aa2ff" stroke-width="5" stroke-linecap="round" stroke-opacity=".85"/>
+        <!-- after branch takes focus, parent runs thin -->
+        <path d="M901 120 L1043 120" stroke="#5aa2ff" stroke-width="2" stroke-opacity=".35" stroke-linecap="round"/>
+
+        <!-- branch: reading article (parked) -->
+        <path d="M639 120 C665 120 665 192 691 192 L711 192" stroke="#a78bfa" stroke-width="3.5" fill="none" stroke-opacity=".8" stroke-linecap="round"/>
+        <path d="M711 192 L748 192" stroke="#a78bfa" stroke-width="2" stroke-dasharray="2 6" stroke-opacity=".4" stroke-linecap="round"/>
+        <circle cx="748" cy="192" r="4.5" fill="none" stroke="#a78bfa" stroke-width="2" stroke-opacity=".8"/>
+
+        <!-- branch: answering support (live) -->
+        <path d="M901 120 C927 120 927 192 953 192 L1035 192" stroke="url(#gsup)" stroke-width="5" fill="none" stroke-linecap="round" filter="url(#soft)"/>
+
+        <!-- wear os sync -->
+        <path d="M231 250 C300 250 320 250 379 250" stroke="#ffaa40" stroke-width="0" fill="none"/>
+        <path d="M379 250 L452 250" stroke="#ffaa40" stroke-width="5" stroke-linecap="round" stroke-opacity=".9"/>
+        <path d="M452 250 L1043 250" stroke="#ffaa40" stroke-width="2" stroke-dasharray="2 7" stroke-opacity=".35" stroke-linecap="round"/>
+        <!-- switch connectors -->
+        <path d="M379 120 C400 120 400 250 379 250 " stroke="rgba(255,255,255,.14)" stroke-width="1.5" fill="none" stroke-dasharray="3 4"/>
+        <path d="M452 250 C431 250 431 120 452 120" stroke="rgba(255,255,255,.14)" stroke-width="1.5" fill="none" stroke-dasharray="3 4"/>
+
+        <!-- capture dots -->
+        <g>
+          <circle cx="125" cy="120" r="5" fill="#5aa2ff"/>
+          <circle cx="332" cy="120" r="3.5" fill="#cdd6ea"/>
+          <circle cx="495" cy="120" r="3.5" fill="#cdd6ea"/>
+          <circle cx="668" cy="192" r="3.5" fill="#cdd6ea"/>
+          <circle cx="836" cy="120" r="3.5" fill="#cdd6ea"/>
+          <circle cx="918" cy="192" r="3.5" fill="#cdd6ea"/>
+          <circle cx="961" cy="192" r="5.5" fill="#2ec66a" filter="url(#soft)"/>
+          <circle cx="404" cy="250" r="3.5" fill="#cdd6ea"/>
+        </g>
+
+        <!-- NOW line -->
+        <line x1="1043" y1="26" x2="1043" y2="352" stroke="#2ec66a" stroke-opacity=".5" stroke-width="1.5"/>
+        <circle cx="1043" cy="192" r="6" fill="#2ec66a" filter="url(#soft)"/>
+        <text x="1054" y="34" font-family="ui-monospace,Menlo,monospace" font-size="10.5" fill="#2ec66a" font-weight="700">NOW 14:26</text>
+        <text x="1054" y="196" font-family="ui-monospace,Menlo,monospace" font-size="10.5" fill="#8b93a7">answering</text>
+        <text x="1054" y="209" font-family="ui-monospace,Menlo,monospace" font-size="10.5" fill="#8b93a7">support</text>
+      </svg>
+    </div>
+
+    <div class="insight">
+      <div class="ins"><div class="cap">READ BACK</div><div class="v">You paused <b>improving AIDX</b> for 25 min to handle <b>wear os sync</b> — the dashed gap is that interlude, drawn honestly.</div></div>
+      <div class="ins"><div class="cap">PATTERN</div><div class="v">Deep-focus block <b>11:05 – 13:41</b> was today’s longest. Your branches cluster after lunch — <i>tangents live in the afternoon.</i></div></div>
+      <div class="ins"><div class="cap">LOOSE END</div><div class="v"><b>reading article</b> has been parked for 1h 51m. <span style="color:var(--blue)">Resume it ↵</span> or let it drift to the archive.</div></div>
+    </div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Lanes are threads, streams are attention.</b> Thick beam = active focus; thin = alive but backgrounded; dashed = paused, drawn as an honest gap rather than hidden. The ✓ ring is a completed thread’s full stop.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>Branches literally branch.</b> Sub-tasks curve off the parent lane and either return (done), fade out with a ○ (parked), or glow onward (live). The green-tipped stream is you, right now.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Zero bookkeeping.</b> The map is a pure render of the append-only events table that Flow already writes on every <i>now / branch / park / done</i>. The visualization costs the user nothing — it’s a receipt, not a form.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>Dots are thoughts.</b> Every capture lands on the stream that owned your attention when you had it. Hovering replays the note with its scope — a time machine for “what was I thinking?”</p></div>
+  <div class="leg"><span class="n">5</span><p><b>Scrub through days.</b> Arrow through yesterday, flip to a week view where each day compresses into one braid — patterns (morning deep work, afternoon tangents) become visible in a way no todo list can show.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Insights, not judgements.</b> The strip below reads the braid back in plain language: interludes, longest block, loose ends with a one-key resume. Flow never scores you — it just remembers on your behalf.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · TAURI DESKTOP CONCEPT — <a href="01-workbench.html">1 · Workbench</a> · <a href="02-quick-capture.html">2 · Quick Capture</a> · <a href="03-companion.html">3 · Companion &amp; Tray</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/1-desktop-app/04-flow-map.html
+++ b/docs/ux/exploration/1-desktop-app/04-flow-map.html
@@ -33,9 +33,13 @@
     display:flex;flex-direction:column}
   .titlebar{height:44px;flex:none;display:flex;align-items:center;gap:14px;padding:0 14px;
     border-bottom:1px solid var(--line);background:rgba(255,255,255,.015)}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .wordmark{font:800 13.5px var(--mono);background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent;white-space:nowrap}
+  .switcher{display:flex;align-items:center;background:rgba(255,255,255,.05);border-radius:14px;padding:3px;font:600 11px var(--mono);white-space:nowrap}
+  .switcher span{padding:4px 12px;border-radius:11px;color:var(--faint)}
+  .switcher .on{background:rgba(255,255,255,.11);color:var(--text);font-weight:700}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .tb-title{flex:1;text-align:center;font:560 12.5px var(--mono);color:var(--dim)}
   .tb-title b{color:var(--text)}
   .tb-close{font:600 11px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:6px;padding:3px 9px}
@@ -100,9 +104,11 @@
 
   <div class="window">
     <div class="titlebar">
-      <div class="lights"><i></i><i></i><i></i></div>
-      <div class="tb-title">◎ flow map — <b>where your attention actually went</b></div>
+      <span class="wordmark">≋ Flow</span>
+      <div class="switcher"><span>◨ Workbench</span><span class="on">◎ Flow Map</span></div>
+      <div class="tb-title">flow map — <b>where your attention actually went</b></div>
       <span class="tb-close">esc ✕</span>
+      <div class="lights"><i></i><i></i><i></i></div>
     </div>
 
     <div class="map-h">

--- a/docs/ux/exploration/1-desktop-app/README.md
+++ b/docs/ux/exploration/1-desktop-app/README.md
@@ -53,8 +53,8 @@ Derived from `assets/hero.svg`:
 Flow is built Linux-first, and the desktop app wears GNOME/Adwaita chrome:
 window controls on the right of the headerbar, a headerbar view switcher, and
 Ctrl/Super key notation throughout (Ctrl+K for the palette, Super+Space for
-Quick Capture). The SVG renditions in `assets/` reflect this; treat any
-macOS-style chrome remaining in the HTML mock-ups as superseded.
+Quick Capture). Both the HTML mock-ups and the SVG renditions in `assets/`
+reflect this.
 
 There are exactly two kinds of bars in the design, and **no Flow window has a
 menu bar**:

--- a/docs/ux/exploration/1-desktop-app/README.md
+++ b/docs/ux/exploration/1-desktop-app/README.md
@@ -1,0 +1,73 @@
+# Liminal Flow — Desktop Design (Tauri)
+
+**This is the chosen design for the Flow desktop app.** Four screens for a
+desktop companion to the `flo` CLI/TUI, targeting Tauri. Each screen is a
+self-contained HTML file — open it in any browser. Annotated callouts on each
+page explain the thinking. The build is tracked by the Flow Desktop epic on
+GitHub, and `assets/` holds SVG renditions of each screen plus the epic's
+dependency diagram for embedding in issues.
+
+| # | Screen | What it covers |
+|---|--------|----------------|
+| 1 | [The Workbench](01-workbench.html) | The main window — streams sidebar, focus stack, notes river, capture bar |
+| 2 | [Quick Capture](02-quick-capture.html) | Global-shortcut palette that floats over any app |
+| 3 | [Companion & Tray](03-companion.html) | Always-on-top focus pill, tray flyout, "welcome back" resume card |
+| 4 | [The Flow Map](04-flow-map.html) | Your day replayed as a braided river, rendered from the events table |
+
+## Design principles
+
+1. **The desktop app is a peer, not a replacement.** It reads and writes the
+   same SQLite store (WAL mode) as the CLI and TUI. `flo now` in a terminal
+   shows up in the desktop app within the existing 250 ms polling contract,
+   and a click on *park* in the tray is indistinguishable from `flo park`.
+   One brain, three faces.
+2. **Same grammar everywhere.** Plain text is a note. `/` opens the identical
+   slash-command palette with the same ranking rules as the TUI
+   (name matches beat description matches). Muscle memory transfers 1:1.
+3. **Ambient, not demanding.** Flow is a working-*memory* sidecar, so the
+   desktop's job is glanceability: the titlebar breadcrumb, the companion
+   pill, the state-coloured window ring and tray icon. Zero notifications by
+   default — the only proactive surface is the opt-in "welcome back" card
+   after system idle.
+4. **Attention drawn as flow.** Threads render as streams; branches visually
+   fork off their parents; the focus stack is a literal stack of cards; the
+   Flow Map braids the whole day. The metaphor in the name becomes the UI.
+5. **Visualisation as a receipt, not a form.** Everything in the Flow Map is
+   a pure render of the append-only events table Flow already writes. The
+   user never enters data to get the picture.
+
+## Visual language
+
+Derived from `assets/hero.svg`:
+
+- Background: `#050507 → #0a1020` gradient, dark-first
+- Brand gradient: `#ffaa40` (orange) → `#f43f5e` (rose) → `#a78bfa` (violet)
+- Flow beams: `#5aa2ff` (blue); active focus: `#2ec66a` (green)
+- State colours: green = active, amber = paused, violet = parked,
+  green ring/tombstone = done
+- Mono accents (`ui-monospace`) for timestamps, scopes, commands and hints —
+  a deliberate nod to Flow's terminal-native roots
+
+## Window inventory & Tauri notes
+
+| Window | Tauri specifics |
+|--------|-----------------|
+| Workbench | Frameless (`decorations: false`), custom titlebar as drag region, min ~980×640. State-coloured focus ring via translucent window + CSS. |
+| Quick Capture | Transparent, undecorated, `always_on_top`, centered near top; summoned via `tauri-plugin-global-shortcut` (e.g. ⌥Space); hides on blur/Esc, never appears in the taskbar (`skip_taskbar`). |
+| Companion pill | Tiny undecorated `always_on_top` window, draggable anywhere, position persisted; expands on hover. |
+| Tray | `TrayIcon` with state-coloured icon + menu built from live store state; recent-streams items call the same resume logic as the TUI's `r`. |
+| Welcome back | Small `always_on_top` card triggered by idle/unlock detection; entirely opt-in via config. |
+
+Backend: the Tauri shell links the existing Rust crates directly (store,
+model, context) rather than shelling out to `flo` — commands are `#[tauri::command]`
+wrappers over the same core APIs the CLI uses, so the Five Core Rules
+(single active thread, auto-pause, branches require a thread, back parks
+branches, immutable events) are enforced in exactly one place.
+
+## Deliberate non-goals
+
+- No task-manager features (due dates, priorities, projects) — Flow tracks
+  attention, not obligations.
+- No productivity scoring or streaks. The Flow Map describes; it never grades.
+- No cloud sync in this concept — the local SQLite store remains the single
+  source of truth.

--- a/docs/ux/exploration/1-desktop-app/README.md
+++ b/docs/ux/exploration/1-desktop-app/README.md
@@ -48,6 +48,44 @@ Derived from `assets/hero.svg`:
 - Mono accents (`ui-monospace`) for timestamps, scopes, commands and hints —
   a deliberate nod to Flow's terminal-native roots
 
+## Linux-first chrome
+
+Flow is built Linux-first, and the desktop app wears GNOME/Adwaita chrome:
+window controls on the right of the headerbar, a headerbar view switcher, and
+Ctrl/Super key notation throughout (Ctrl+K for the palette, Super+Space for
+Quick Capture). The SVG renditions in `assets/` reflect this; treat any
+macOS-style chrome remaining in the HTML mock-ups as superseded.
+
+There are exactly two kinds of bars in the design, and **no Flow window has a
+menu bar**:
+
+1. **App topbars** (Workbench, Flow Map): the shared Liminal HQ topbar
+   pattern — **Spindle's `Topbar` component is the implementation
+   reference** (window-control pattern originally from Threshold). Layout:
+   brand mark, view switcher, contextual content over a drag region, then
+   platform-appropriate window controls — on Linux, transparent buttons with
+   thin line glyphs (minimise / maximise / close), Adwaita-style hover.
+   Anything menu-like lives behind ⚙ in the topbar or the Ctrl+K palette.
+2. **The GNOME shell top bar** appears only in scene-setting mock-ups (the
+   Companion) because those depict the whole desktop — the tray indicator and
+   its flyout hang from the shell bar, as GNOME intends. It is not Flow
+   chrome.
+
+Transient surfaces (Quick Capture, the Companion pill, the welcome-back card)
+have no chrome at all — no headerbar, no controls, dismissed by Esc/blur.
+
+## Navigating between screens
+
+- The headerbar carries an Adwaita-style **view switcher** between the two
+  full views: **Workbench ⇄ Flow Map**. Esc returns to the Workbench.
+- The **Today rail** in the Workbench is a second, contextual route into the
+  Flow Map (click the braid or ◎).
+- **Quick Capture** and the **Companion pill** are transient windows, not
+  views — they are summoned (Super+Space, always-on-top) and both offer an
+  "open" action that raises the Workbench.
+- **Ctrl+K** opens the palette from either view; commands there can jump
+  views as well as act on the store.
+
 ## Window inventory & Tauri notes
 
 | Window | Tauri specifics |

--- a/docs/ux/exploration/1-desktop-app/assets/companion.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/companion.svg
@@ -10,14 +10,16 @@
   </defs>
   <rect width="1200" height="640" rx="16" fill="url(#bg)"/>
 
-  <!-- menubar -->
-  <rect width="1200" height="30" rx="16" fill="rgba(10,14,26,.85)"/>
-  <rect y="16" width="1200" height="14" fill="rgba(10,14,26,.85)"/>
+  <!-- GNOME top bar -->
+  <rect width="1200" height="30" rx="16" fill="rgba(6,9,17,.92)"/>
+  <rect y="16" width="1200" height="14" fill="rgba(6,9,17,.92)"/>
   <line x1="0" y1="30" x2="1200" y2="30" stroke="rgba(255,255,255,.08)"/>
-  <text x="16" y="20" font-family="Menlo,monospace" font-size="11" fill="#5a627a">File   Edit   View</text>
-  <rect x="1044" y="7" width="52" height="17" rx="5" fill="rgba(46,198,106,.12)"/>
-  <text x="1070" y="20" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#2ec66a" font-weight="700">≋ flo</text>
-  <text x="1150" y="20" font-family="Menlo,monospace" font-size="11" fill="#5a627a">14:26</text>
+  <text x="16" y="20" font-family="Menlo,monospace" font-size="11" fill="#8b93a7">Activities</text>
+  <rect x="546" y="6" width="108" height="19" rx="9.5" fill="rgba(255,255,255,.06)"/>
+  <text x="600" y="20" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#c8cdd8">Aug 14  14:26</text>
+  <rect x="1052" y="6" width="132" height="19" rx="9.5" fill="rgba(255,255,255,.06)"/>
+  <text x="1076" y="20" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#2ec66a" font-weight="700">≋ flo</text>
+  <text x="1132" y="20" text-anchor="middle" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">🔊 ⚡ ▾</text>
 
   <!-- fake windows -->
   <g opacity=".5">
@@ -74,7 +76,7 @@
   <line x1="852" y1="228" x2="1160" y2="228" stroke="rgba(255,255,255,.08)"/>
   <g font-family="Menlo,monospace" font-size="10" font-weight="700" fill="#8b93a7">
     <rect x="866" y="240" width="120" height="28" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>
-    <text x="926" y="258" text-anchor="middle">› capture ⌥␣</text>
+    <text x="926" y="258" text-anchor="middle">› capture Super+␣</text>
     <rect x="992" y="240" width="76" height="28" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>
     <text x="1030" y="258" text-anchor="middle">⏸ pause</text>
     <rect x="1074" y="240" width="72" height="28" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>

--- a/docs/ux/exploration/1-desktop-app/assets/companion.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/companion.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="640" viewBox="0 0 1200 640" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-labelledby="t">
+  <title id="t">Flow Desktop — the always-on-top Companion pill, tray flyout, and welcome-back card</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#131a2d"/><stop offset="55%" stop-color="#0a0e1c"/><stop offset="100%" stop-color="#110f21"/>
+    </linearGradient>
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="2.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1200" height="640" rx="16" fill="url(#bg)"/>
+
+  <!-- menubar -->
+  <rect width="1200" height="30" rx="16" fill="rgba(10,14,26,.85)"/>
+  <rect y="16" width="1200" height="14" fill="rgba(10,14,26,.85)"/>
+  <line x1="0" y1="30" x2="1200" y2="30" stroke="rgba(255,255,255,.08)"/>
+  <text x="16" y="20" font-family="Menlo,monospace" font-size="11" fill="#5a627a">File   Edit   View</text>
+  <rect x="1044" y="7" width="52" height="17" rx="5" fill="rgba(46,198,106,.12)"/>
+  <text x="1070" y="20" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#2ec66a" font-weight="700">≋ flo</text>
+  <text x="1150" y="20" font-family="Menlo,monospace" font-size="11" fill="#5a627a">14:26</text>
+
+  <!-- fake windows -->
+  <g opacity=".5">
+    <rect x="120" y="210" width="480" height="400" rx="10" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.05)"/>
+    <rect x="700" y="330" width="380" height="280" rx="10" fill="rgba(255,255,255,.03)" stroke="rgba(255,255,255,.05)"/>
+  </g>
+
+  <!-- collapsed pill -->
+  <rect x="56" y="60" width="286" height="36" rx="18" fill="rgba(10,15,28,.95)" stroke="rgba(46,198,106,.35)" stroke-width="1.5"/>
+  <circle cx="76" cy="78" r="4" fill="#2ec66a" filter="url(#glow)"/>
+  <circle cx="92" cy="78" r="2" fill="#8b93a7"/><circle cx="100" cy="78" r="2" fill="#5aa2ff"/>
+  <text x="112" y="83" font-family="Menlo,monospace" font-size="12.5" fill="#e8ecf6" font-weight="600">answering support</text>
+  <text x="322" y="83" text-anchor="end" font-family="Menlo,monospace" font-size="11" fill="#5a627a">23m</text>
+  <text x="360" y="82" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">⟵ 30-pt sliver: state · stack depth · title · timer</text>
+
+  <!-- expanded pill -->
+  <rect x="56" y="128" width="300" height="102" rx="16" fill="rgba(10,15,28,.96)" stroke="rgba(46,198,106,.3)" stroke-width="1.5"/>
+  <circle cx="78" cy="150" r="4" fill="#2ec66a" filter="url(#glow)"/>
+  <text x="90" y="155" font-family="Menlo,monospace" font-size="12.5" fill="#e8ecf6" font-weight="600">answering support</text>
+  <text x="338" y="155" text-anchor="end" font-family="Menlo,monospace" font-size="11" fill="#5a627a">23m</text>
+  <text x="90" y="174" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">↳ in <tspan fill="#8b93a7" font-weight="600">improving AIDX</tspan> · ⌂ component-library</text>
+  <g font-family="Menlo,monospace" font-size="10.5" font-weight="700">
+    <rect x="72" y="188" width="64" height="26" rx="8" fill="rgba(46,198,106,.13)" stroke="rgba(46,198,106,.35)"/>
+    <text x="104" y="205" text-anchor="middle" fill="#dffbe9">✓ done</text>
+    <rect x="142" y="188" width="64" height="26" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="174" y="205" text-anchor="middle" fill="#8b93a7">⧉ park</text>
+    <rect x="212" y="188" width="64" height="26" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="244" y="205" text-anchor="middle" fill="#8b93a7">⇤ back</text>
+    <rect x="282" y="188" width="60" height="26" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="312" y="205" text-anchor="middle" fill="#8b93a7">◨ open</text>
+  </g>
+  <text x="374" y="184" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">⟵ hover blooms into the four verbs</text>
+
+  <!-- tray flyout -->
+  <rect x="852" y="38" width="308" height="248" rx="14" fill="rgba(10,15,28,.97)" stroke="rgba(255,255,255,.12)" stroke-width="1.5"/>
+  <text x="868" y="62" font-family="Menlo,monospace" font-size="9.5" letter-spacing="2" fill="#5a627a" font-weight="700">NOW</text>
+  <circle cx="874" cy="80" r="4" fill="#2ec66a" filter="url(#glow)"/>
+  <text x="886" y="85" font-size="13" fill="#e8ecf6" font-weight="600">answering support</text>
+  <text x="1144" y="85" text-anchor="end" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">23m</text>
+  <text x="886" y="102" font-family="Menlo,monospace" font-size="10" fill="#5a627a">↳ improving AIDX · ⎇ feature/aidx</text>
+  <line x1="852" y1="114" x2="1160" y2="114" stroke="rgba(255,255,255,.08)"/>
+  <text x="868" y="134" font-family="Menlo,monospace" font-size="9.5" letter-spacing="2" fill="#5a627a" font-weight="700">RESUME — RECENT STREAMS</text>
+  <g font-size="12.5" fill="#8b93a7">
+    <circle cx="876" cy="152" r="3.5" fill="#a78bfa"/><text x="890" y="157">reading article</text>
+    <rect x="1080" y="144" width="64" height="16" rx="4" fill="none" stroke="rgba(255,255,255,.12)"/>
+    <text x="1112" y="156" text-anchor="middle" font-family="Menlo,monospace" font-size="9.5" fill="#5a627a">parked</text>
+    <circle cx="876" cy="180" r="3.5" fill="#ffaa40"/><text x="890" y="185">wear os sync</text>
+    <rect x="1080" y="172" width="64" height="16" rx="4" fill="none" stroke="rgba(255,255,255,.12)"/>
+    <text x="1112" y="184" text-anchor="middle" font-family="Menlo,monospace" font-size="9.5" fill="#5a627a">2h</text>
+    <circle cx="876" cy="208" r="3.5" fill="#ffaa40"/><text x="890" y="213">component library docs</text>
+    <rect x="1080" y="200" width="64" height="16" rx="4" fill="none" stroke="rgba(255,255,255,.12)"/>
+    <text x="1112" y="212" text-anchor="middle" font-family="Menlo,monospace" font-size="9.5" fill="#5a627a">1d</text>
+  </g>
+  <line x1="852" y1="228" x2="1160" y2="228" stroke="rgba(255,255,255,.08)"/>
+  <g font-family="Menlo,monospace" font-size="10" font-weight="700" fill="#8b93a7">
+    <rect x="866" y="240" width="120" height="28" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="926" y="258" text-anchor="middle">› capture ⌥␣</text>
+    <rect x="992" y="240" width="76" height="28" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="1030" y="258" text-anchor="middle">⏸ pause</text>
+    <rect x="1074" y="240" width="72" height="28" rx="8" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="1110" y="258" text-anchor="middle">◨ open</text>
+  </g>
+
+  <!-- welcome back card -->
+  <rect x="330" y="410" width="540" height="190" rx="16" fill="rgba(11,16,30,.97)" stroke="rgba(255,170,64,.35)" stroke-width="1.5"/>
+  <text x="352" y="440" font-family="Menlo,monospace" font-size="9.5" letter-spacing="2" fill="#ffaa40" font-weight="700">WELCOME BACK · AWAY 25 MIN</text>
+  <text x="352" y="466" font-size="16" fill="#e8ecf6" font-weight="650">Where were you?</text>
+  <text x="352" y="488" font-size="12.5" fill="#8b93a7">You were 23 minutes into <tspan fill="#e8ecf6" font-weight="600">answering support</tspan>. Your last thought:</text>
+  <rect x="352" y="500" width="496" height="34" rx="6" fill="rgba(90,162,255,.05)"/>
+  <rect x="352" y="500" width="3" height="34" fill="#5aa2ff"/>
+  <text x="366" y="522" font-family="Menlo,monospace" font-size="12" fill="#c7cddc">“need to check auth flow” <tspan fill="#5a627a">— 14:02, on ⎇ feature/aidx</tspan></text>
+  <g font-family="Menlo,monospace" font-size="11.5" font-weight="700">
+    <rect x="352" y="548" width="220" height="30" rx="9" fill="rgba(46,198,106,.13)" stroke="rgba(46,198,106,.4)"/>
+    <text x="462" y="568" text-anchor="middle" fill="#dffbe9">↻ resume where I left off</text>
+    <rect x="582" y="548" width="160" height="30" rx="9" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="662" y="568" text-anchor="middle" fill="#8b93a7">⏸ actually, pause it</text>
+    <rect x="752" y="548" width="96" height="30" rx="9" fill="none" stroke="rgba(255,255,255,.14)" stroke-dasharray="4 4"/>
+    <text x="800" y="568" text-anchor="middle" fill="#8b93a7">✕ dismiss</text>
+  </g>
+</svg>

--- a/docs/ux/exploration/1-desktop-app/assets/epic-structure.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/epic-structure.svg
@@ -71,7 +71,7 @@
     <!-- 6 capture -->
     <rect x="540" y="368" width="200" height="64" rx="12" fill="#111726" stroke="#2ec66a" stroke-width="1.5"/>
     <text x="556" y="394" font-size="13" fill="#e6eaf2" font-weight="650">6 · Capture &amp; palette</text>
-    <text x="556" y="414" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">notes · slash commands · ⌘K</text>
+    <text x="556" y="414" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">notes · slash commands · Ctrl+K</text>
 
     <!-- 7 quick capture -->
     <rect x="800" y="385" width="200" height="64" rx="12" fill="#111726" stroke="#ffaa40" stroke-width="1.5"/>

--- a/docs/ux/exploration/1-desktop-app/assets/epic-structure.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/epic-structure.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1220" height="560" viewBox="0 0 1220 560" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-labelledby="t">
+  <title id="t">Flow Desktop epic — build steps and their blocking relationships</title>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#8b93a7"/>
+    </marker>
+  </defs>
+  <rect width="1220" height="560" rx="14" fill="#0a0d14" stroke="rgba(255,255,255,.12)"/>
+
+  <!-- phase labels -->
+  <g font-family="Menlo,monospace" font-size="10.5" letter-spacing="2" font-weight="700">
+    <text x="130" y="46" text-anchor="middle" fill="#5aa2ff">FOUNDATION</text>
+    <text x="380" y="46" text-anchor="middle" fill="#a78bfa">PLATFORM</text>
+    <text x="640" y="46" text-anchor="middle" fill="#2ec66a">WORKBENCH</text>
+    <text x="900" y="46" text-anchor="middle" fill="#ffaa40">SATELLITE WINDOWS</text>
+    <text x="1110" y="46" text-anchor="middle" fill="#f43f5e">SHIP</text>
+  </g>
+  <g stroke-width="2" opacity=".5">
+    <line x1="80" y1="56" x2="180" y2="56" stroke="#5aa2ff"/>
+    <line x1="330" y1="56" x2="430" y2="56" stroke="#a78bfa"/>
+    <line x1="590" y1="56" x2="690" y2="56" stroke="#2ec66a"/>
+    <line x1="850" y1="56" x2="950" y2="56" stroke="#ffaa40"/>
+    <line x1="1060" y1="56" x2="1160" y2="56" stroke="#f43f5e"/>
+  </g>
+
+  <!-- edges -->
+  <g fill="none" stroke="#8b93a7" stroke-opacity=".45" stroke-width="1.5" marker-end="url(#arr)">
+    <path d="M230 285 C255 285 255 215 278 213"/>
+    <path d="M230 295 C255 295 255 365 278 367"/>
+    <path d="M480 205 C515 200 515 148 538 145"/>
+    <path d="M480 213 C520 220 520 270 538 273"/>
+    <path d="M480 219 C520 240 510 390 538 399"/>
+    <path d="M480 375 C515 370 510 160 538 152"/>
+    <path d="M480 379 C515 372 515 288 538 281"/>
+    <path d="M480 383 C515 383 515 405 538 405"/>
+    <path d="M740 405 C770 405 770 415 798 415"/>
+    <path d="M480 195 C560 100 760 108 798 137"/>
+    <path d="M480 367 C540 330 740 300 798 285"/>
+    <path d="M740 145 C790 100 1010 150 1038 240"/>
+    <path d="M740 277 C770 277 990 270 1038 268"/>
+    <path d="M740 397 C790 430 990 360 1038 296"/>
+  </g>
+
+  <!-- nodes -->
+  <g>
+    <!-- 1 scaffold -->
+    <rect x="30" y="260" width="200" height="64" rx="12" fill="#111726" stroke="#5aa2ff" stroke-width="1.5"/>
+    <text x="46" y="286" font-size="13" fill="#e6eaf2" font-weight="650">1 · Scaffold app crate</text>
+    <text x="46" y="306" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">Tauri 2 · Svelte 5 · Vite · CI</text>
+
+    <!-- 2 bridge -->
+    <rect x="280" y="180" width="200" height="64" rx="12" fill="#111726" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="296" y="206" font-size="13" fill="#e6eaf2" font-weight="650">2 · Core bridge &amp; sync</text>
+    <text x="296" y="226" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">commands · events ≤250ms</text>
+
+    <!-- 3 shell -->
+    <rect x="280" y="335" width="200" height="64" rx="12" fill="#111726" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="296" y="361" font-size="13" fill="#e6eaf2" font-weight="650">3 · Shell &amp; design tokens</text>
+    <text x="296" y="381" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">frameless · titlebar · theme</text>
+
+    <!-- 4 sidebar -->
+    <rect x="540" y="112" width="200" height="64" rx="12" fill="#111726" stroke="#2ec66a" stroke-width="1.5"/>
+    <text x="556" y="138" font-size="13" fill="#e6eaf2" font-weight="650">4 · Streams sidebar</text>
+    <text x="556" y="158" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">threads · branches · nav</text>
+
+    <!-- 5 focus -->
+    <rect x="540" y="240" width="200" height="64" rx="12" fill="#111726" stroke="#2ec66a" stroke-width="1.5"/>
+    <text x="556" y="266" font-size="13" fill="#e6eaf2" font-weight="650">5 · Focus stack &amp; notes</text>
+    <text x="556" y="286" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">stack cards · scopes · trail</text>
+
+    <!-- 6 capture -->
+    <rect x="540" y="368" width="200" height="64" rx="12" fill="#111726" stroke="#2ec66a" stroke-width="1.5"/>
+    <text x="556" y="394" font-size="13" fill="#e6eaf2" font-weight="650">6 · Capture &amp; palette</text>
+    <text x="556" y="414" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">notes · slash commands · ⌘K</text>
+
+    <!-- 7 quick capture -->
+    <rect x="800" y="385" width="200" height="64" rx="12" fill="#111726" stroke="#ffaa40" stroke-width="1.5"/>
+    <text x="816" y="411" font-size="13" fill="#e6eaf2" font-weight="650">7 · Quick Capture</text>
+    <text x="816" y="431" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">global shortcut overlay</text>
+
+    <!-- 8 companion -->
+    <rect x="800" y="112" width="200" height="64" rx="12" fill="#111726" stroke="#ffaa40" stroke-width="1.5"/>
+    <text x="816" y="138" font-size="13" fill="#e6eaf2" font-weight="650">8 · Companion &amp; tray</text>
+    <text x="816" y="158" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">pill · tray · welcome back</text>
+
+    <!-- 9 flow map -->
+    <rect x="800" y="253" width="200" height="64" rx="12" fill="#111726" stroke="#ffaa40" stroke-width="1.5"/>
+    <text x="816" y="279" font-size="13" fill="#e6eaf2" font-weight="650">9 · Flow Map &amp; rail</text>
+    <text x="816" y="299" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">day braid from events</text>
+
+    <!-- 10 ship -->
+    <rect x="1040" y="236" width="160" height="64" rx="12" fill="#111726" stroke="#f43f5e" stroke-width="1.5"/>
+    <text x="1056" y="262" font-size="13" fill="#e6eaf2" font-weight="650">10 · Package</text>
+    <text x="1056" y="282" font-family="Menlo,monospace" font-size="10" fill="#8b93a7">bundles · release CI</text>
+  </g>
+
+  <text x="30" y="520" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">arrows read “unblocks” — an issue starts when everything pointing at it is done · 4/5/6 can run in parallel · 7 reuses the palette from 6 · 8/9 need only the bridge and tokens</text>
+</svg>

--- a/docs/ux/exploration/1-desktop-app/assets/flow-map.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/flow-map.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="700" viewBox="0 0 1240 700" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-labelledby="t">
+  <title id="t">Flow Desktop — the Flow Map: the day replayed as a braided river of attention</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0c1222"/><stop offset="100%" stop-color="#080d1a"/>
+    </linearGradient>
+    <linearGradient id="gsup" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#5aa2ff"/><stop offset="100%" stop-color="#2ec66a"/>
+    </linearGradient>
+    <filter id="soft" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1240" height="700" rx="14" fill="url(#bg)" stroke="rgba(90,162,255,.2)" stroke-width="1.5"/>
+
+  <!-- titlebar -->
+  <line x1="0" y1="44" x2="1240" y2="44" stroke="rgba(255,255,255,.08)"/>
+  <circle cx="26" cy="22" r="6" fill="#ff5f57"/><circle cx="46" cy="22" r="6" fill="#febc2e"/><circle cx="66" cy="22" r="6" fill="#28c840"/>
+  <text x="620" y="27" text-anchor="middle" font-family="Menlo,monospace" font-size="12.5" fill="#8b93a7">◎ flow map — <tspan fill="#e8ecf6" font-weight="700">where your attention actually went</tspan></text>
+
+  <!-- header -->
+  <rect x="24" y="58" width="248" height="34" rx="10" fill="none" stroke="rgba(255,255,255,.12)"/>
+  <text x="148" y="80" text-anchor="middle" font-family="Menlo,monospace" font-size="13" fill="#e8ecf6" font-weight="650">‹  Today · Thu Aug 14  ›</text>
+  <g font-family="Menlo,monospace" font-size="10.5">
+    <rect x="678" y="61" width="86" height="26" rx="13" fill="none" stroke="rgba(255,255,255,.1)"/>
+    <text x="721" y="78" text-anchor="middle" fill="#8b93a7"><tspan fill="#e8ecf6" font-weight="700">3</tspan> threads</text>
+    <rect x="772" y="61" width="92" height="26" rx="13" fill="none" stroke="rgba(255,255,255,.1)"/>
+    <text x="818" y="78" text-anchor="middle" fill="#8b93a7"><tspan fill="#e8ecf6" font-weight="700">3</tspan> branches</text>
+    <rect x="872" y="61" width="92" height="26" rx="13" fill="none" stroke="rgba(255,255,255,.1)"/>
+    <text x="918" y="78" text-anchor="middle" fill="#8b93a7"><tspan fill="#e8ecf6" font-weight="700">26</tspan> captures</text>
+    <rect x="972" y="61" width="240" height="26" rx="13" fill="rgba(46,198,106,.08)" stroke="rgba(46,198,106,.35)"/>
+    <text x="1092" y="78" text-anchor="middle" fill="#dffbe9">longest focus <tspan font-weight="700">1h 12m</tspan></text>
+  </g>
+
+  <!-- lane labels -->
+  <g font-family="Menlo,monospace" font-size="11.5" fill="#8b93a7" font-weight="600">
+    <text x="24" y="222">improving AIDX</text>
+    <text x="24" y="238" font-size="9.5" fill="#5a627a" font-weight="500">⌂ component-library</text>
+    <text x="24" y="296" font-size="10.5" fill="#5a627a" font-weight="500">↳ branches</text>
+    <text x="24" y="352">wear os sync</text>
+    <text x="24" y="368" font-size="9.5" fill="#5a627a" font-weight="500">⌂ wear-companion</text>
+    <text x="24" y="432">fix release pipeline</text>
+    <text x="24" y="448" font-size="9.5" fill="#5a627a" font-weight="500">✓ done 09:50</text>
+  </g>
+
+  <!-- braid, offset -->
+  <g transform="translate(10,100)">
+    <g stroke="rgba(255,255,255,.05)" stroke-width="1">
+      <line x1="263" y1="30" x2="263" y2="382"/><line x1="437" y1="30" x2="437" y2="382"/>
+      <line x1="610" y1="30" x2="610" y2="382"/><line x1="783" y1="30" x2="783" y2="382"/>
+      <line x1="957" y1="30" x2="957" y2="382"/>
+    </g>
+    <g font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">
+      <text x="90" y="406">09:00</text><text x="245" y="406">10:00</text><text x="419" y="406">11:00</text>
+      <text x="592" y="406">12:00</text><text x="765" y="406">13:00</text><text x="939" y="406">14:00</text>
+    </g>
+
+    <path d="M90 330 L235 330" stroke="#5aa2ff" stroke-opacity=".55" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="235" cy="330" r="7" fill="none" stroke="#2ec66a" stroke-width="2.5"/>
+    <path d="M231.5 330 l2.5 2.5 l5 -5" stroke="#2ec66a" stroke-width="2" fill="none"/>
+
+    <path d="M125 120 L379 120" stroke="#5aa2ff" stroke-width="5" stroke-linecap="round" stroke-opacity=".85"/>
+    <path d="M379 120 L452 120" stroke="#5aa2ff" stroke-width="2.5" stroke-dasharray="2 7" stroke-opacity=".45" stroke-linecap="round"/>
+    <path d="M452 120 L901 120" stroke="#5aa2ff" stroke-width="5" stroke-linecap="round" stroke-opacity=".85"/>
+    <path d="M901 120 L1043 120" stroke="#5aa2ff" stroke-width="2" stroke-opacity=".35" stroke-linecap="round"/>
+
+    <path d="M639 120 C665 120 665 192 691 192 L711 192" stroke="#a78bfa" stroke-width="3.5" fill="none" stroke-opacity=".8" stroke-linecap="round"/>
+    <path d="M711 192 L748 192" stroke="#a78bfa" stroke-width="2" stroke-dasharray="2 6" stroke-opacity=".4" stroke-linecap="round"/>
+    <circle cx="748" cy="192" r="4.5" fill="none" stroke="#a78bfa" stroke-width="2" stroke-opacity=".8"/>
+
+    <path d="M901 120 C927 120 927 192 953 192 L1035 192" stroke="url(#gsup)" stroke-width="5" fill="none" stroke-linecap="round" filter="url(#soft)"/>
+
+    <path d="M379 250 L452 250" stroke="#ffaa40" stroke-width="5" stroke-linecap="round" stroke-opacity=".9"/>
+    <path d="M452 250 L1043 250" stroke="#ffaa40" stroke-width="2" stroke-dasharray="2 7" stroke-opacity=".35" stroke-linecap="round"/>
+    <path d="M379 120 C400 120 400 250 379 250" stroke="rgba(255,255,255,.14)" stroke-width="1.5" fill="none" stroke-dasharray="3 4"/>
+    <path d="M452 250 C431 250 431 120 452 120" stroke="rgba(255,255,255,.14)" stroke-width="1.5" fill="none" stroke-dasharray="3 4"/>
+
+    <circle cx="125" cy="120" r="5" fill="#5aa2ff"/>
+    <circle cx="332" cy="120" r="3.5" fill="#cdd6ea"/>
+    <circle cx="495" cy="120" r="3.5" fill="#cdd6ea"/>
+    <circle cx="668" cy="192" r="3.5" fill="#cdd6ea"/>
+    <circle cx="836" cy="120" r="3.5" fill="#cdd6ea"/>
+    <circle cx="918" cy="192" r="3.5" fill="#cdd6ea"/>
+    <circle cx="961" cy="192" r="5.5" fill="#2ec66a" filter="url(#soft)"/>
+    <circle cx="404" cy="250" r="3.5" fill="#cdd6ea"/>
+
+    <line x1="1043" y1="26" x2="1043" y2="382" stroke="#2ec66a" stroke-opacity=".5" stroke-width="1.5"/>
+    <circle cx="1043" cy="192" r="6" fill="#2ec66a" filter="url(#soft)"/>
+    <text x="1054" y="34" font-family="Menlo,monospace" font-size="10.5" fill="#2ec66a" font-weight="700">NOW 14:26</text>
+    <text x="1054" y="196" font-family="Menlo,monospace" font-size="10.5" fill="#8b93a7">answering</text>
+    <text x="1054" y="209" font-family="Menlo,monospace" font-size="10.5" fill="#8b93a7">support</text>
+
+    <!-- tooltip -->
+    <rect x="880" y="120" width="238" height="46" rx="10" fill="rgba(11,16,30,.97)" stroke="rgba(46,198,106,.35)"/>
+    <text x="894" y="139" font-family="Menlo,monospace" font-size="11.5" fill="#c7cddc">“need to check auth flow”</text>
+    <text x="894" y="156" font-family="Menlo,monospace" font-size="9.5" fill="#5a627a">14:02 · answering support · ⎇ feature/aidx</text>
+  </g>
+
+  <!-- insight strip -->
+  <g font-family="Menlo,monospace">
+    <rect x="24" y="558" width="384" height="112" rx="12" fill="rgba(255,255,255,.015)" stroke="rgba(255,255,255,.08)"/>
+    <text x="40" y="582" font-size="9.5" letter-spacing="1.6" fill="#5a627a" font-weight="700">READ BACK</text>
+    <text x="40" y="604" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc">You paused <tspan font-weight="650" fill="#e8ecf6">improving AIDX</tspan> for 25 min to handle</text>
+    <text x="40" y="622" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc"><tspan font-weight="650" fill="#e8ecf6">wear os sync</tspan> — the dashed gap is that interlude,</text>
+    <text x="40" y="640" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc">drawn honestly.</text>
+
+    <rect x="424" y="558" width="384" height="112" rx="12" fill="rgba(255,255,255,.015)" stroke="rgba(255,255,255,.08)"/>
+    <text x="440" y="582" font-size="9.5" letter-spacing="1.6" fill="#5a627a" font-weight="700">PATTERN</text>
+    <text x="440" y="604" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc">Deep-focus block <tspan font-weight="650" fill="#e8ecf6">11:05 – 13:41</tspan> was today's</text>
+    <text x="440" y="622" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc">longest. Your branches cluster after lunch —</text>
+    <text x="440" y="640" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#8b93a7" font-style="italic">tangents live in the afternoon.</text>
+
+    <rect x="824" y="558" width="392" height="112" rx="12" fill="rgba(255,255,255,.015)" stroke="rgba(255,255,255,.08)"/>
+    <text x="840" y="582" font-size="9.5" letter-spacing="1.6" fill="#5a627a" font-weight="700">LOOSE END</text>
+    <text x="840" y="604" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc"><tspan font-weight="650" fill="#e8ecf6">reading article</tspan> has been parked for 1h 51m.</text>
+    <text x="840" y="622" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc"><tspan fill="#5aa2ff">Resume it ↵</tspan> or let it drift to the archive.</text>
+  </g>
+</svg>

--- a/docs/ux/exploration/1-desktop-app/assets/flow-map.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/flow-map.svg
@@ -7,16 +7,31 @@
     <linearGradient id="gsup" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#5aa2ff"/><stop offset="100%" stop-color="#2ec66a"/>
     </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffaa40"/><stop offset="55%" stop-color="#f43f5e"/><stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
     <filter id="soft" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
   <rect width="1240" height="700" rx="14" fill="url(#bg)" stroke="rgba(90,162,255,.2)" stroke-width="1.5"/>
 
-  <!-- titlebar -->
+  <!-- titlebar (GNOME headerbar) -->
   <line x1="0" y1="44" x2="1240" y2="44" stroke="rgba(255,255,255,.08)"/>
-  <circle cx="26" cy="22" r="6" fill="#ff5f57"/><circle cx="46" cy="22" r="6" fill="#febc2e"/><circle cx="66" cy="22" r="6" fill="#28c840"/>
-  <text x="620" y="27" text-anchor="middle" font-family="Menlo,monospace" font-size="12.5" fill="#8b93a7">◎ flow map — <tspan fill="#e8ecf6" font-weight="700">where your attention actually went</tspan></text>
+  <!-- logo (Spindle topbar pattern) -->
+  <text x="16" y="27" font-family="Menlo,monospace" font-size="13.5" font-weight="800" fill="url(#brand)">≋ Flow</text>
+  <!-- view switcher -->
+  <rect x="96" y="8" width="248" height="28" rx="14" fill="rgba(255,255,255,.05)"/>
+  <rect x="221" y="10.5" width="120" height="23" rx="11.5" fill="rgba(255,255,255,.11)"/>
+  <text x="160" y="26" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#5a627a" font-weight="600">◨ Workbench</text>
+  <text x="281" y="26" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#e6eaf2" font-weight="700">◎ Flow Map</text>
+  <text x="620" y="27" text-anchor="middle" font-family="Menlo,monospace" font-size="12.5" fill="#8b93a7">flow map — <tspan fill="#e6eaf2" font-weight="700">where your attention actually went</tspan></text>
+  <!-- window controls (Spindle/Threshold Linux pattern: transparent, thin line glyphs) -->
+  <g stroke="#9aa3b5" stroke-width="1.3" fill="none">
+    <line x1="1131" y1="25" x2="1141" y2="25"/>
+    <rect x="1163.5" y="17.5" width="9" height="9"/>
+    <path d="M1195.5 17.5 l9 9 M1204.5 17.5 l-9 9"/>
+  </g>
 
   <!-- header -->
   <rect x="24" y="58" width="248" height="34" rx="10" fill="none" stroke="rgba(255,255,255,.12)"/>

--- a/docs/ux/exploration/1-desktop-app/assets/quick-capture.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/quick-capture.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="640" viewBox="0 0 1200 640" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-labelledby="t">
+  <title id="t">Flow Desktop — the Quick Capture palette floating over the desktop</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#141a2e"/><stop offset="55%" stop-color="#0a0e1c"/><stop offset="100%" stop-color="#120f22"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="640" rx="16" fill="url(#bg)"/>
+
+  <!-- blurred fake windows behind -->
+  <g opacity=".5">
+    <rect x="40" y="44" width="520" height="420" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.05)"/>
+    <line x1="40" y1="72" x2="560" y2="72" stroke="rgba(255,255,255,.05)"/>
+    <rect x="56" y="92" width="300" height="8" rx="4" fill="rgba(255,255,255,.05)"/>
+    <rect x="56" y="112" width="400" height="8" rx="4" fill="rgba(255,255,255,.05)"/>
+    <rect x="56" y="132" width="240" height="8" rx="4" fill="rgba(255,255,255,.05)"/>
+    <rect x="700" y="110" width="452" height="460" rx="10" fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.05)"/>
+    <line x1="700" y1="138" x2="1152" y2="138" stroke="rgba(255,255,255,.05)"/>
+    <rect x="716" y="158" width="320" height="8" rx="4" fill="rgba(255,255,255,.05)"/>
+    <rect x="716" y="178" width="230" height="8" rx="4" fill="rgba(255,255,255,.05)"/>
+  </g>
+  <rect width="1200" height="640" rx="16" fill="rgba(4,6,12,.55)"/>
+
+  <!-- palette: slash state -->
+  <rect x="280" y="70" width="640" height="304" rx="16" fill="rgba(11,16,30,.96)" stroke="rgba(90,162,255,.3)" stroke-width="1.5"/>
+  <circle cx="304" cy="94" r="4" fill="#2ec66a"/>
+  <text x="316" y="99" font-family="Menlo,monospace" font-size="11.5" fill="#8b93a7">capturing to <tspan fill="#e8ecf6" font-weight="700">answering support</tspan> <tspan fill="#5a627a">· improving AIDX</tspan></text>
+  <text x="898" y="99" text-anchor="end" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">⌂ component-library · ⎇ feature/aidx</text>
+  <line x1="280" y1="112" x2="920" y2="112" stroke="rgba(255,255,255,.08)"/>
+  <text x="302" y="146" font-family="Menlo,monospace" font-size="17" fill="#5aa2ff" font-weight="800">›</text>
+  <text x="322" y="146" font-family="Menlo,monospace" font-size="16" fill="#e8ecf6">/par</text>
+  <rect x="362" y="130" width="9" height="20" fill="#5aa2ff"/>
+  <line x1="280" y1="164" x2="920" y2="164" stroke="rgba(255,255,255,.08)"/>
+  <!-- command rows -->
+  <rect x="290" y="172" width="620" height="40" rx="10" fill="rgba(90,162,255,.12)" stroke="rgba(90,162,255,.35)"/>
+  <g font-family="Menlo,monospace">
+    <text x="306" y="197" font-size="13.5" fill="#5aa2ff" font-weight="700">/park</text>
+    <text x="396" y="196" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc">park the active branch — keep it warm, drop it from focus</text>
+    <rect x="836" y="180" width="62" height="18" rx="5" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="867" y="193" text-anchor="middle" font-size="9" fill="#5a627a" font-weight="700">BRANCH</text>
+    <text x="306" y="239" font-size="13.5" fill="#5aa2ff" font-weight="700">/pause</text>
+    <text x="396" y="238" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#8b93a7">pause the current thread with an optional note</text>
+    <rect x="836" y="224" width="62" height="18" rx="5" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="867" y="237" text-anchor="middle" font-size="9" fill="#5a627a" font-weight="700">THREAD</text>
+    <text x="306" y="281" font-size="13.5" fill="#5aa2ff" font-weight="700">/back</text>
+    <text x="396" y="280" font-size="12" font-family="-apple-system,'Segoe UI',sans-serif" fill="#8b93a7">return to the parent thread, parking active branches</text>
+    <rect x="836" y="266" width="62" height="18" rx="5" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="867" y="279" text-anchor="middle" font-size="9" fill="#5a627a" font-weight="700">STACK</text>
+  </g>
+  <line x1="280" y1="330" x2="920" y2="330" stroke="rgba(255,255,255,.08)"/>
+  <text x="300" y="356" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">↑↓ choose   ⇥ complete   ↵ run   esc vanish</text>
+  <text x="898" y="356" text-anchor="end" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">⌘↵ run &amp; open workbench</text>
+
+  <!-- palette: note state -->
+  <rect x="320" y="452" width="560" height="98" rx="16" fill="rgba(11,16,30,.96)" stroke="rgba(46,198,106,.3)" stroke-width="1.5"/>
+  <text x="342" y="490" font-family="Menlo,monospace" font-size="16" fill="#2ec66a" font-weight="800">›</text>
+  <text x="362" y="490" font-family="Menlo,monospace" font-size="13.5" fill="#e8ecf6">rate limiter also needs the retry-after header</text>
+  <rect x="742" y="474" width="9" height="20" fill="#2ec66a"/>
+  <line x1="320" y1="508" x2="880" y2="508" stroke="rgba(255,255,255,.08)"/>
+  <text x="342" y="532" font-family="Menlo,monospace" font-size="10.5" fill="#2ec66a">↵ note → <tspan fill="#dffbe9" font-weight="700">answering support</tspan></text>
+  <text x="858" y="532" text-anchor="end" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">no window switch · you never left your editor</text>
+
+  <!-- caption -->
+  <text x="600" y="610" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#5a627a">⌥ Space anywhere → transparent always-on-top window · plain text is a note · / is the shared command grammar</text>
+</svg>

--- a/docs/ux/exploration/1-desktop-app/assets/quick-capture.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/quick-capture.svg
@@ -49,7 +49,7 @@
   </g>
   <line x1="280" y1="330" x2="920" y2="330" stroke="rgba(255,255,255,.08)"/>
   <text x="300" y="356" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">↑↓ choose   ⇥ complete   ↵ run   esc vanish</text>
-  <text x="898" y="356" text-anchor="end" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">⌘↵ run &amp; open workbench</text>
+  <text x="898" y="356" text-anchor="end" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">Ctrl+↵ run &amp; open workbench</text>
 
   <!-- palette: note state -->
   <rect x="320" y="452" width="560" height="98" rx="16" fill="rgba(11,16,30,.96)" stroke="rgba(46,198,106,.3)" stroke-width="1.5"/>
@@ -61,5 +61,5 @@
   <text x="858" y="532" text-anchor="end" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">no window switch · you never left your editor</text>
 
   <!-- caption -->
-  <text x="600" y="610" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#5a627a">⌥ Space anywhere → transparent always-on-top window · plain text is a note · / is the shared command grammar</text>
+  <text x="600" y="610" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#5a627a">Super+Space anywhere → transparent always-on-top window · plain text is a note · / is the shared command grammar</text>
 </svg>

--- a/docs/ux/exploration/1-desktop-app/assets/workbench.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/workbench.svg
@@ -4,18 +4,33 @@
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0c1222"/><stop offset="100%" stop-color="#080d1a"/>
     </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffaa40"/><stop offset="55%" stop-color="#f43f5e"/><stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
     <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
       <feGaussianBlur stdDeviation="2.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
   </defs>
   <rect width="1240" height="780" rx="14" fill="url(#bg)" stroke="rgba(46,198,106,.25)" stroke-width="1.5"/>
 
-  <!-- titlebar -->
+  <!-- titlebar (GNOME headerbar) -->
   <line x1="0" y1="44" x2="1240" y2="44" stroke="rgba(255,255,255,.08)"/>
-  <circle cx="26" cy="22" r="6" fill="#ff5f57"/><circle cx="46" cy="22" r="6" fill="#febc2e"/><circle cx="66" cy="22" r="6" fill="#28c840"/>
+  <!-- logo (Spindle topbar pattern) -->
+  <text x="16" y="27" font-family="Menlo,monospace" font-size="13.5" font-weight="800" fill="url(#brand)">≋ Flow</text>
+  <!-- view switcher -->
+  <rect x="96" y="8" width="248" height="28" rx="14" fill="rgba(255,255,255,.05)"/>
+  <rect x="99" y="10.5" width="122" height="23" rx="11.5" fill="rgba(255,255,255,.11)"/>
+  <text x="160" y="26" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#e6eaf2" font-weight="700">◨ Workbench</text>
+  <text x="282" y="26" text-anchor="middle" font-family="Menlo,monospace" font-size="11" fill="#5a627a" font-weight="600">◎ Flow Map</text>
   <circle cx="470" cy="22" r="4" fill="#2ec66a" filter="url(#glow)"/>
   <text x="482" y="27" font-family="Menlo,monospace" font-size="13" fill="#e8ecf6" font-weight="600">improving AIDX <tspan fill="#5a627a">▸</tspan> answering support <tspan fill="#5a627a">· 23m in focus</tspan></text>
-  <text x="1140" y="27" font-family="Menlo,monospace" font-size="13" fill="#8b93a7">◎  ⌘K  ⚙</text>
+  <text x="1046" y="27" font-family="Menlo,monospace" font-size="13" fill="#8b93a7">Ctrl+K  ⚙</text>
+  <!-- window controls (Spindle/Threshold Linux pattern: transparent, thin line glyphs) -->
+  <g stroke="#9aa3b5" stroke-width="1.3" fill="none">
+    <line x1="1131" y1="25" x2="1141" y2="25"/>
+    <rect x="1163.5" y="17.5" width="9" height="9"/>
+    <path d="M1195.5 17.5 l9 9 M1204.5 17.5 l-9 9"/>
+  </g>
 
   <!-- sidebar -->
   <line x1="292" y1="44" x2="292" y2="688" stroke="rgba(255,255,255,.08)"/>
@@ -146,5 +161,5 @@
   <text x="74" y="730" font-family="Menlo,monospace" font-size="12.5" fill="#5a627a">capture a thought — plain text becomes a note…</text>
   <rect x="1022" y="712" width="180" height="26" rx="13" fill="rgba(46,198,106,.08)" stroke="rgba(46,198,106,.25)"/>
   <text x="1112" y="729" text-anchor="middle" font-family="Menlo,monospace" font-size="10.5" fill="#2ec66a" font-weight="700">→ answering support</text>
-  <text x="26" y="768" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">/ commands    ? hints    ⌃↑↓ note history    ↵ capture</text>
+  <text x="26" y="768" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">/ commands    ? hints    Ctrl+↑↓ note history    ↵ capture</text>
 </svg>

--- a/docs/ux/exploration/1-desktop-app/assets/workbench.svg
+++ b/docs/ux/exploration/1-desktop-app/assets/workbench.svg
@@ -1,0 +1,150 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="780" viewBox="0 0 1240 780" font-family="-apple-system,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-labelledby="t">
+  <title id="t">Flow Desktop — the Workbench screen</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0c1222"/><stop offset="100%" stop-color="#080d1a"/>
+    </linearGradient>
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="2.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1240" height="780" rx="14" fill="url(#bg)" stroke="rgba(46,198,106,.25)" stroke-width="1.5"/>
+
+  <!-- titlebar -->
+  <line x1="0" y1="44" x2="1240" y2="44" stroke="rgba(255,255,255,.08)"/>
+  <circle cx="26" cy="22" r="6" fill="#ff5f57"/><circle cx="46" cy="22" r="6" fill="#febc2e"/><circle cx="66" cy="22" r="6" fill="#28c840"/>
+  <circle cx="470" cy="22" r="4" fill="#2ec66a" filter="url(#glow)"/>
+  <text x="482" y="27" font-family="Menlo,monospace" font-size="13" fill="#e8ecf6" font-weight="600">improving AIDX <tspan fill="#5a627a">▸</tspan> answering support <tspan fill="#5a627a">· 23m in focus</tspan></text>
+  <text x="1140" y="27" font-family="Menlo,monospace" font-size="13" fill="#8b93a7">◎  ⌘K  ⚙</text>
+
+  <!-- sidebar -->
+  <line x1="292" y1="44" x2="292" y2="688" stroke="rgba(255,255,255,.08)"/>
+  <rect x="0" y="44" width="292" height="644" fill="rgba(0,0,0,.14)"/>
+  <text x="18" y="76" font-family="Menlo,monospace" font-size="11" letter-spacing="2" fill="#8b93a7" font-weight="700">STREAMS</text>
+  <text x="274" y="76" text-anchor="end" font-family="Menlo,monospace" font-size="10" fill="#5a627a">2 live · 2 paused · 1 done</text>
+
+  <!-- active thread -->
+  <rect x="10" y="90" width="272" height="48" rx="10" fill="rgba(46,198,106,.09)" stroke="rgba(46,198,106,.25)"/>
+  <circle cx="26" cy="107" r="4.5" fill="#2ec66a" filter="url(#glow)"/>
+  <text x="40" y="111" font-size="13.5" fill="#e8ecf6" font-weight="600">improving AIDX</text>
+  <text x="40" y="128" font-family="Menlo,monospace" font-size="9.5" fill="#5a627a">⌂ component-library · started 09:12</text>
+  <!-- branch: live -->
+  <path d="M26 140 v10 q0 8 8 8 h6" fill="none" stroke="#2ec66a" stroke-width="2"/>
+  <rect x="36" y="148" width="246" height="26" rx="7" fill="rgba(90,162,255,.08)"/>
+  <circle cx="48" cy="161" r="3.5" fill="#2ec66a" filter="url(#glow)"/>
+  <text x="60" y="165" font-size="12.5" fill="#e8ecf6" font-weight="570">answering support</text>
+  <!-- branch: parked -->
+  <path d="M26 140 v40 q0 8 8 8 h6" fill="none" stroke="rgba(90,162,255,.4)" stroke-width="2"/>
+  <circle cx="48" cy="191" r="3.5" fill="#a78bfa"/>
+  <text x="60" y="195" font-size="12.5" fill="#5a627a">reading article</text>
+  <rect x="162" y="182" width="56" height="15" rx="7.5" fill="rgba(167,139,250,.12)"/>
+  <text x="190" y="193" text-anchor="middle" font-family="Menlo,monospace" font-size="8.5" fill="#a78bfa" font-weight="700">PARKED</text>
+
+  <!-- paused threads -->
+  <circle cx="26" cy="228" r="4" fill="#ffaa40"/>
+  <text x="40" y="232" font-size="13" fill="#8b93a7" font-weight="530">wear os sync</text>
+  <rect x="134" y="220" width="74" height="15" rx="7.5" fill="rgba(255,170,64,.1)"/>
+  <text x="171" y="231" text-anchor="middle" font-family="Menlo,monospace" font-size="8.5" fill="#ffaa40" font-weight="700">PAUSED 2H</text>
+  <text x="40" y="247" font-family="Menlo,monospace" font-size="9.5" fill="#5a627a">⌂ wear-companion</text>
+
+  <circle cx="26" cy="278" r="4" fill="#ffaa40"/>
+  <text x="40" y="282" font-size="13" fill="#8b93a7" font-weight="530">component library docs</text>
+  <rect x="196" y="270" width="72" height="15" rx="7.5" fill="rgba(255,170,64,.1)"/>
+  <text x="232" y="281" text-anchor="middle" font-family="Menlo,monospace" font-size="8.5" fill="#ffaa40" font-weight="700">YESTERDAY</text>
+  <text x="40" y="297" font-family="Menlo,monospace" font-size="9.5" fill="#5a627a">⌂ component-library</text>
+
+  <!-- done tombstone -->
+  <circle cx="26" cy="328" r="4" fill="none" stroke="#2ec66a" stroke-width="2"/>
+  <text x="40" y="332" font-size="13" fill="#5a627a">fix release pipeline</text>
+  <line x1="40" y1="328" x2="152" y2="328" stroke="rgba(46,198,106,.5)"/>
+  <rect x="162" y="320" width="44" height="15" rx="7.5" fill="rgba(46,198,106,.1)"/>
+  <text x="184" y="331" text-anchor="middle" font-family="Menlo,monospace" font-size="8.5" fill="#2ec66a" font-weight="700">DONE</text>
+
+  <rect x="16" y="638" width="260" height="34" rx="9" fill="none" stroke="rgba(255,255,255,.14)" stroke-dasharray="4 4"/>
+  <text x="146" y="659" text-anchor="middle" font-family="Menlo,monospace" font-size="11.5" fill="#8b93a7" font-weight="600">+ new thread  /now</text>
+
+  <!-- centre: focus stack -->
+  <rect x="348" y="72" width="690" height="44" rx="12" fill="#0d1426" stroke="rgba(255,255,255,.08)" opacity=".6"/>
+  <rect x="366" y="84" width="58" height="18" rx="5" fill="none" stroke="rgba(255,255,255,.14)"/>
+  <text x="395" y="97" text-anchor="middle" font-family="Menlo,monospace" font-size="9" fill="#5a627a" font-weight="700">THREAD</text>
+  <text x="436" y="98" font-size="12.5" fill="#8b93a7" font-weight="560">improving AIDX</text>
+
+  <rect x="322" y="100" width="742" height="158" rx="14" fill="#121a30" stroke="rgba(46,198,106,.35)" stroke-width="1.5"/>
+  <text x="346" y="142" font-size="23" fill="#e8ecf6" font-weight="650">answering support</text>
+  <rect x="924" y="118" width="118" height="26" rx="13" fill="rgba(46,198,106,.1)" stroke="rgba(46,198,106,.3)"/>
+  <circle cx="938" cy="131" r="3.5" fill="#2ec66a" filter="url(#glow)"/>
+  <text x="948" y="135" font-family="Menlo,monospace" font-size="10" fill="#2ec66a" font-weight="700">ACTIVE · 23M</text>
+  <!-- scope chips -->
+  <g font-family="Menlo,monospace" font-size="11">
+    <rect x="346" y="158" width="164" height="24" rx="7" fill="rgba(90,162,255,.06)" stroke="rgba(90,162,255,.16)"/>
+    <text x="356" y="174" fill="#8b93a7"><tspan fill="#5aa2ff" font-weight="700">⌂</tspan> component-library</text>
+    <rect x="518" y="158" width="124" height="24" rx="7" fill="rgba(90,162,255,.06)" stroke="rgba(90,162,255,.16)"/>
+    <text x="528" y="174" fill="#8b93a7"><tspan fill="#5aa2ff" font-weight="700">⎇</tspan> feature/aidx</text>
+    <rect x="650" y="158" width="192" height="24" rx="7" fill="rgba(90,162,255,.06)" stroke="rgba(90,162,255,.16)"/>
+    <text x="660" y="174" fill="#8b93a7"><tspan fill="#5aa2ff" font-weight="700">~</tspan> /code/component-library</text>
+  </g>
+  <!-- action buttons -->
+  <g font-family="Menlo,monospace" font-size="12" font-weight="600">
+    <rect x="346" y="200" width="94" height="32" rx="9" fill="rgba(46,198,106,.14)" stroke="rgba(46,198,106,.4)"/>
+    <text x="393" y="220" text-anchor="middle" fill="#dffbe9">✓ done</text>
+    <rect x="450" y="200" width="150" height="32" rx="9" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="525" y="220" text-anchor="middle" fill="#8b93a7">⇤ back to thread</text>
+    <rect x="610" y="200" width="80" height="32" rx="9" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="650" y="220" text-anchor="middle" fill="#8b93a7">⧉ park</text>
+    <rect x="700" y="200" width="150" height="32" rx="9" fill="none" stroke="rgba(255,255,255,.14)"/>
+    <text x="775" y="220" text-anchor="middle" fill="#8b93a7">＋ branch deeper</text>
+  </g>
+
+  <!-- notes -->
+  <text x="324" y="296" font-family="Menlo,monospace" font-size="11" letter-spacing="2" fill="#8b93a7" font-weight="700">NOTES &amp; TRAIL</text>
+  <rect x="812" y="280" width="252" height="24" rx="8" fill="none" stroke="rgba(255,255,255,.1)"/>
+  <rect x="812" y="280" width="102" height="24" rx="8" fill="rgba(90,162,255,.12)"/>
+  <g font-family="Menlo,monospace" font-size="10.5" font-weight="600">
+    <text x="863" y="296" text-anchor="middle" fill="#5aa2ff">this branch</text>
+    <text x="962" y="296" text-anchor="middle" fill="#5a627a">whole thread</text>
+    <text x="1038" y="296" text-anchor="middle" fill="#5a627a">all</text>
+  </g>
+  <line x1="324" y1="318" x2="620" y2="318" stroke="rgba(255,255,255,.08)"/>
+  <text x="693" y="322" text-anchor="middle" font-family="Menlo,monospace" font-size="9.5" letter-spacing="2" fill="#5a627a" font-weight="700">TODAY</text>
+  <line x1="766" y1="318" x2="1064" y2="318" stroke="rgba(255,255,255,.08)"/>
+  <g font-family="Menlo,monospace">
+    <text x="324" y="352" font-size="11" fill="#5a627a">14:02</text>
+    <text x="392" y="352" font-size="13" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc">need to check auth flow</text>
+    <text x="324" y="388" font-size="11" fill="#5a627a">13:47</text>
+    <text x="392" y="388" font-size="13" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc">support ticket #482 — token refresh 401s after idle</text>
+    <rect x="800" y="374" width="118" height="19" rx="5" fill="rgba(167,139,250,.1)"/>
+    <text x="808" y="387" font-size="10" fill="#a78bfa">⎇ feature/aidx</text>
+    <text x="324" y="424" font-size="11" fill="#5a627a">13:41</text>
+    <text x="392" y="424" font-size="11.5" fill="#5a627a">▶ branched from <tspan fill="#5aa2ff" font-weight="600">improving AIDX</tspan> — “answering support”</text>
+    <text x="324" y="460" font-size="11" fill="#5a627a">11:20</text>
+    <text x="392" y="460" font-size="13" font-family="-apple-system,'Segoe UI',sans-serif" fill="#c7cddc">AIDX scoring feels off for long sessions — sample rate?</text>
+    <text x="324" y="496" font-size="11" fill="#5a627a">09:12</text>
+    <text x="392" y="496" font-size="11.5" fill="#5a627a">● thread started via <tspan fill="#5aa2ff" font-weight="600">flo now</tspan> in zsh</text>
+  </g>
+
+  <!-- today rail -->
+  <line x1="1176" y1="44" x2="1176" y2="688" stroke="rgba(255,255,255,.08)"/>
+  <text x="1213" y="86" font-family="Menlo,monospace" font-size="9" letter-spacing="2" fill="#5a627a" font-weight="700" transform="rotate(90 1213 86)">TODAY</text>
+  <g fill="none" stroke-linecap="round">
+    <path d="M1208 130 v110" stroke="#5aa2ff" stroke-opacity=".5" stroke-width="2.5"/>
+    <path d="M1208 240 c0 26 10 34 10 60 c0 26 -8 36 -10 52" stroke="#a78bfa" stroke-opacity=".55" stroke-width="2"/>
+    <path d="M1208 240 v160" stroke="#5aa2ff" stroke-opacity=".35" stroke-width="2.5" stroke-dasharray="2 5"/>
+    <path d="M1208 400 v190" stroke="#2ec66a" stroke-opacity=".8" stroke-width="2.5"/>
+  </g>
+  <circle cx="1208" cy="130" r="3.5" fill="#5aa2ff"/>
+  <circle cx="1218" cy="300" r="2.5" fill="#a78bfa"/>
+  <circle cx="1208" cy="400" r="3.5" fill="#2ec66a"/>
+  <circle cx="1208" cy="590" r="4" fill="#2ec66a" filter="url(#glow)"/>
+  <rect x="1192" y="620" width="32" height="32" rx="9" fill="none" stroke="rgba(255,255,255,.14)"/>
+  <text x="1208" y="641" text-anchor="middle" font-size="14" fill="#8b93a7">◎</text>
+
+  <!-- capture bar -->
+  <line x1="0" y1="688" x2="1240" y2="688" stroke="rgba(255,255,255,.08)"/>
+  <rect x="20" y="702" width="1200" height="46" rx="12" fill="rgba(8,13,26,.9)" stroke="rgba(90,162,255,.3)" stroke-width="1.5"/>
+  <text x="40" y="731" font-family="Menlo,monospace" font-size="15" fill="#5aa2ff" font-weight="800">›</text>
+  <rect x="58" y="716" width="8" height="18" fill="#5aa2ff"/>
+  <text x="74" y="730" font-family="Menlo,monospace" font-size="12.5" fill="#5a627a">capture a thought — plain text becomes a note…</text>
+  <rect x="1022" y="712" width="180" height="26" rx="13" fill="rgba(46,198,106,.08)" stroke="rgba(46,198,106,.25)"/>
+  <text x="1112" y="729" text-anchor="middle" font-family="Menlo,monospace" font-size="10.5" fill="#2ec66a" font-weight="700">→ answering support</text>
+  <text x="26" y="768" font-family="Menlo,monospace" font-size="10.5" fill="#5a627a">/ commands    ? hints    ⌃↑↓ note history    ↵ capture</text>
+</svg>

--- a/docs/ux/exploration/2-metaphor-concepts/01-desk.html
+++ b/docs/ux/exploration/2-metaphor-concepts/01-desk.html
@@ -37,9 +37,9 @@
 
   /* toolbar */
   .bar{position:absolute;top:0;left:0;right:0;height:44px;display:flex;align-items:center;gap:14px;padding:0 16px;z-index:8}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .bar .where{font:560 12px var(--mono);color:var(--faint)}
   .bar .zoom{margin-left:auto;display:flex;border:1px solid var(--line);border-radius:8px;overflow:hidden;font:600 11px var(--mono)}
   .bar .zoom span{padding:5px 12px;color:var(--faint)}

--- a/docs/ux/exploration/2-metaphor-concepts/01-desk.html
+++ b/docs/ux/exploration/2-metaphor-concepts/01-desk.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Rethinks — A · The Desk</title>
+<style>
+  :root{
+    --bg0:#050507; --bg1:#0a1020; --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --text:#e8ecf6; --dim:#8b93a7; --faint:#5a627a;
+    --orange:#ffaa40; --rose:#f43f5e; --violet:#a78bfa; --blue:#5aa2ff; --green:#2ec66a;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:
+      radial-gradient(1100px 500px at 15% -10%, rgba(167,139,250,.10), transparent 60%),
+      radial-gradient(900px 500px at 90% 0%, rgba(255,170,64,.07), transparent 55%),
+      linear-gradient(160deg,var(--bg0),var(--bg1));
+    color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px;
+  }
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:720px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:1240px;margin:0 auto}
+  .window{position:relative;border-radius:14px;overflow:hidden;height:740px;
+    border:1px solid var(--line2);
+    box-shadow:0 40px 90px rgba(0,0,0,.6);
+    background:
+      radial-gradient(620px 460px at 44% 46%, rgba(255,214,150,.10), rgba(255,214,150,.03) 55%, transparent 72%),
+      radial-gradient(900px 700px at 44% 46%, rgba(90,162,255,.05), transparent 70%),
+      linear-gradient(175deg,#0b101f,#070b16)}
+
+  /* toolbar */
+  .bar{position:absolute;top:0;left:0;right:0;height:44px;display:flex;align-items:center;gap:14px;padding:0 16px;z-index:8}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .bar .where{font:560 12px var(--mono);color:var(--faint)}
+  .bar .zoom{margin-left:auto;display:flex;border:1px solid var(--line);border-radius:8px;overflow:hidden;font:600 11px var(--mono)}
+  .bar .zoom span{padding:5px 12px;color:var(--faint)}
+  .bar .zoom .on{background:rgba(255,255,255,.06);color:var(--text)}
+  .bar .search{font:520 12px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:8px;padding:5px 12px}
+
+  /* cards on the desk */
+  .card{position:absolute;width:230px;border-radius:12px;padding:13px 15px;background:linear-gradient(170deg,#151d33,#0f1628);
+    border:1px solid var(--line2);box-shadow:0 14px 34px rgba(0,0,0,.5)}
+  .card .t{font-size:14px;font-weight:600;line-height:1.35}
+  .card .m{font:500 10.5px var(--mono);color:var(--faint);margin-top:6px}
+  .card .note{font:450 11.5px var(--mono);color:#aab3c7;border-left:2px solid var(--blue);padding:3px 0 3px 9px;margin-top:9px}
+  .card.hot{border-color:rgba(46,198,106,.5);box-shadow:0 0 0 1px rgba(46,198,106,.2), 0 22px 50px rgba(0,0,0,.55), 0 0 44px rgba(255,214,150,.12)}
+  .card.hot .t{font-size:15.5px}
+  .hot-dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 9px var(--green);margin-right:7px;vertical-align:1px}
+  .card.tangent{width:196px;border-color:rgba(90,162,255,.4);background:linear-gradient(170deg,#131b31,#0e1526)}
+  .clip{position:absolute;top:-9px;left:18px;width:34px;height:14px;border:2px solid var(--blue);border-bottom:none;border-radius:8px 8px 0 0;opacity:.75}
+  .card.cool{opacity:.72}
+  .card.cool .t{color:#c3cadb;font-weight:560}
+  .card.cold{opacity:.42;filter:saturate(.6)}
+  .card.frozen{opacity:.22;filter:saturate(.3) blur(.4px)}
+  .stack2::before,.stack2::after{content:"";position:absolute;inset:0;border-radius:12px;border:1px solid var(--line);background:#0e1526;z-index:-1}
+  .stack2::before{transform:rotate(2.6deg) translate(5px,4px)}
+  .stack2::after{transform:rotate(-2deg) translate(-4px,6px)}
+  .tag{display:inline-block;font:600 9px var(--mono);letter-spacing:.1em;border-radius:5px;padding:2px 6px;margin-top:8px}
+  .tag.amber{color:var(--orange);background:rgba(255,170,64,.1)}
+  .tag.violet{color:var(--violet);background:rgba(167,139,250,.12)}
+
+  /* horizon */
+  .horizon{position:absolute;right:-40px;top:120px;width:220px;height:520px;transform:rotate(6deg);
+    background:linear-gradient(90deg,transparent,rgba(5,7,12,.9));pointer-events:none}
+  .horizon-label{position:absolute;right:22px;top:360px;writing-mode:vertical-rl;font:600 10px var(--mono);letter-spacing:.26em;color:var(--faint)}
+
+  /* minimap */
+  .minimap{position:absolute;right:18px;bottom:18px;width:170px;height:110px;border-radius:10px;z-index:8;
+    border:1px solid var(--line2);background:rgba(8,12,22,.9);box-shadow:0 10px 30px rgba(0,0,0,.5)}
+  .minimap b{position:absolute;top:7px;left:10px;font:650 8.5px var(--mono);letter-spacing:.2em;color:var(--faint)}
+  .minimap .vp{position:absolute;left:34px;top:26px;width:74px;height:52px;border:1.5px solid rgba(255,214,150,.6);border-radius:4px;background:rgba(255,214,150,.06)}
+  .minimap i{position:absolute;width:5px;height:5px;border-radius:2px;background:var(--faint)}
+
+  /* whisper bar */
+  .whisper{position:absolute;left:50%;bottom:20px;transform:translateX(-50%);z-index:8;
+    display:flex;align-items:center;gap:10px;width:460px;border:1px solid rgba(90,162,255,.3);border-radius:999px;
+    background:rgba(8,13,26,.92);padding:10px 18px;font:450 13px var(--mono);color:var(--faint)}
+  .whisper .p{color:var(--blue);font-weight:700}
+
+  .pin{position:absolute;z-index:9;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,var(--orange),var(--rose));color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+
+  .legend{max-width:1240px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,var(--orange),var(--rose));
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1240px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Ground-up Rethinks · Concept A of 4</div>
+<h1>FLOW / <span class="g">DESK</span></h1>
+<p class="sub">No lists, no tree, no sidebar. Your work lives on an infinite desk under a pool of lamplight. What you're doing sits in the light; what you've set aside stays <i>exactly where you put it</i> — because spatial memory is the one kind that never needs a search box.</p>
+
+<div class="stage">
+  <div class="pin" style="top:280px;left:395px">1</div>
+  <div class="pin" style="top:150px;left:640px">2</div>
+  <div class="pin" style="top:120px;left:120px">3</div>
+  <div class="pin" style="top:410px;right:120px">4</div>
+  <div class="pin" style="bottom:96px;right:200px">5</div>
+  <div class="pin" style="bottom:64px;left:340px">6</div>
+
+  <div class="window">
+    <div class="bar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <span class="where">the desk · thursday</span>
+      <div class="zoom"><span class="on">desk</span><span>room</span><span>year</span></div>
+      <span class="search">⌕ find anything…</span>
+    </div>
+
+    <!-- hot cluster: the lamp -->
+    <div class="card hot" style="left:378px;top:302px;transform:rotate(-1deg)">
+      <div class="t"><span class="hot-dot"></span>answering support ticket #482</div>
+      <div class="m">under the lamp · 23 min</div>
+      <div class="note">token refresh 401s after idle — check auth flow</div>
+    </div>
+    <div class="card tangent" style="left:560px;top:222px;transform:rotate(2.4deg)">
+      <span class="clip"></span>
+      <div class="t">tangent: read the AIDX scoring paper</div>
+      <div class="m">clipped to #482 · will follow it back</div>
+    </div>
+
+    <!-- mid-distance: warm but resting -->
+    <div class="card cool stack2" style="left:96px;top:170px;transform:rotate(-3deg)">
+      <div class="t">improving AIDX</div>
+      <div class="m">a stack of 3 · this morning</div>
+      <span class="tag amber">RESTING · 1H</span>
+    </div>
+    <div class="card cool" style="left:150px;top:470px;transform:rotate(2deg)">
+      <div class="t">wear os sync</div>
+      <div class="m">left here at 11:05</div>
+      <span class="tag amber">RESTING · 3H</span>
+    </div>
+
+    <!-- far: cooling -->
+    <div class="card cold" style="left:700px;top:500px;transform:rotate(-2.5deg);width:200px">
+      <div class="t">component library docs</div>
+      <div class="m">yesterday</div>
+      <span class="tag violet">DRIFTING</span>
+    </div>
+    <div class="card cold" style="right:150px;top:150px;transform:rotate(3deg);width:190px">
+      <div class="t">reading article</div>
+      <div class="m">tuesday</div>
+      <span class="tag violet">DRIFTING</span>
+    </div>
+    <div class="card frozen" style="right:60px;top:300px;transform:rotate(-4deg);width:180px">
+      <div class="t">fix release pipeline</div>
+      <div class="m">done · sliding off the desk</div>
+    </div>
+
+    <div class="horizon"></div>
+    <div class="horizon-label">THE EDGE · THINGS FALL OFF GENTLY</div>
+
+    <div class="minimap">
+      <b>DESK</b>
+      <span class="vp"></span>
+      <i style="left:52px;top:44px;background:var(--green)"></i>
+      <i style="left:22px;top:32px"></i>
+      <i style="left:28px;top:74px"></i>
+      <i style="left:118px;top:82px"></i>
+      <i style="left:142px;top:38px"></i>
+    </div>
+
+    <div class="whisper"><span class="p">›</span> drop a thought on the desk…</div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>The lamp is the only "active" state.</b> Whatever sits in the pool of light is what you're doing — there is no active flag, no status field. Drag a card into the light and the one already there slides just outside the glow, still warm. Focus is a place, not a property.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>Tangents are paper-clipped.</b> A quick side-quest clips onto the card that spawned it and rides along. Unclip it and it becomes its own card; finish it and it slips under its parent. No tree view — the relationship is physical.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Piles instead of projects.</b> Toss related cards together and they become a stack with a scruffy, human silhouette. You organise the desk the way you organise a real one: roughly, spatially, by feel — and you find things the same way.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>Neglect is visible as temperature.</b> Untouched cards slowly cool: colour drains, they drift toward the edge, and eventually they slide off the desk into the archive — silently. Nothing nags. The desk stays the size of your actual attention.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>Zoom is time.</b> <i>Desk</i> is today; <i>room</i> pulls back to weeks (piles become islands); <i>year</i> renders the archive as a shoreline of everything that ever slid off the edge. Panning replaces every list this app refuses to have.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>The whisper bar.</b> One input, bottom centre. Type a thought and it lands as a card wherever your viewport is; type onto a selected card and it becomes ink on that card. Capture never opens a dialog.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · GROUND-UP RETHINKS — next: <a href="02-one.html">B · One</a> · <a href="03-dialogue.html">C · Dialogue</a> · <a href="04-garden.html">D · Garden</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/2-metaphor-concepts/02-one.html
+++ b/docs/ux/exploration/2-metaphor-concepts/02-one.html
@@ -32,8 +32,9 @@
     box-shadow:0 0 0 1px rgba(46,198,106,.14), 0 40px 90px rgba(0,0,0,.6);
     background:radial-gradient(900px 620px at 50% 42%, #101830, #080d19 70%)}
 
-  .lights{position:absolute;top:16px;left:16px;display:flex;gap:8px;z-index:5}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block;background:#2a3049}
+  .lights{position:absolute;top:16px;right:20px;display:flex;gap:16px;z-index:5;font:400 13px var(--mono);color:#5d6579}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
 
   /* corners */
   .corner{position:absolute;z-index:5;font:560 11.5px var(--mono);color:var(--faint)}
@@ -125,9 +126,9 @@
       <div class="beneath"><i></i><i></i></div>
     </div>
 
-    <div class="verb up"><b>↑</b> DONE <kbd>⌘↵</kbd></div>
-    <div class="verb down"><b>↓</b> SET ASIDE <kbd>⌘⎋</kbd></div>
-    <div class="verb left"><b>→</b> TANGENT <kbd>⌘T</kbd></div>
+    <div class="verb up"><b>↑</b> DONE <kbd>Ctrl+↵</kbd></div>
+    <div class="verb down"><b>↓</b> SET ASIDE <kbd>Ctrl+Esc</kbd></div>
+    <div class="verb left"><b>→</b> TANGENT <kbd>Ctrl+T</kbd></div>
 
     <div class="peek-l"><small>← improving AIDX waits underneath</small></div>
 
@@ -145,7 +146,7 @@
       <div class="mini"><div class="t">reading article</div><div class="m">set aside tue</div></div>
       <div class="mini dim"><div class="t">component library docs</div><div class="m">yesterday</div></div>
       <div class="mini dim"><div class="t">plan v0.0.6</div><div class="m">someday · no guilt</div></div>
-      <div class="hint"><kbd>⌘L</kbd> open later · slides over, never stays</div>
+      <div class="hint"><kbd>Ctrl+L</kbd> open later · slides over, never stays</div>
     </div>
 
     <div class="thought"><span class="p">›</span> think out loud — it sticks to this card…</div>
@@ -158,7 +159,7 @@
   <div class="leg"><span class="n">3</span><p><b>Three verbs total.</b> Done (up), set aside (down), tangent (right). Every gesture animates the card physically off-screen in that direction, so your hands learn the grammar in a day. There is deliberately no "edit" — cards are intentions, not documents.</p></div>
   <div class="leg"><span class="n">4</span><p><b>The interrupted card haunts the edge.</b> When you take a tangent, the parent doesn't vanish into a list — it stays as a glowing sliver on the left edge, physically <i>underneath</i>. Finishing the tangent slides the parent back in. Unclosed loops are visible as geometry, not badge counts.</p></div>
   <div class="leg"><span class="n">5</span><p><b>The breath bar, not a timer.</b> A soft fill that swells over the first ~25 minutes and then just glows. It never counts down, never buzzes. It exists so that "how long have I been here?" has an ambient answer instead of an anxious one.</p></div>
-  <div class="leg"><span class="n">6</span><p><b>Thoughts stick to the card.</b> One underline input. Whatever you type is stamped onto the current card with a timestamp — the card accumulates a margin of your thinking, which becomes tomorrow's re-entry ramp. The "later" tray (right) slides over on ⌘L and closes on its own; it cannot be pinned open.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Thoughts stick to the card.</b> One underline input. Whatever you type is stamped onto the current card with a timestamp — the card accumulates a margin of your thinking, which becomes tomorrow's re-entry ramp. The "later" tray (right) slides over on Ctrl+L and closes on its own; it cannot be pinned open.</p></div>
 </div>
 
 <div class="foot">LIMINAL FLOW · GROUND-UP RETHINKS — <a href="01-desk.html">A · Desk</a> · next: <a href="03-dialogue.html">C · Dialogue</a> · <a href="04-garden.html">D · Garden</a></div>

--- a/docs/ux/exploration/2-metaphor-concepts/02-one.html
+++ b/docs/ux/exploration/2-metaphor-concepts/02-one.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Rethinks — B · One</title>
+<style>
+  :root{
+    --bg0:#050507; --bg1:#0a1020; --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --text:#e8ecf6; --dim:#8b93a7; --faint:#5a627a;
+    --orange:#ffaa40; --rose:#f43f5e; --violet:#a78bfa; --blue:#5aa2ff; --green:#2ec66a;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:
+      radial-gradient(1100px 500px at 15% -10%, rgba(167,139,250,.10), transparent 60%),
+      radial-gradient(900px 500px at 90% 0%, rgba(255,170,64,.07), transparent 55%),
+      linear-gradient(160deg,var(--bg0),var(--bg1));
+    color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px;
+  }
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:700px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:1240px;margin:0 auto}
+  .window{position:relative;border-radius:14px;overflow:hidden;height:720px;
+    border:1px solid var(--line2);
+    box-shadow:0 0 0 1px rgba(46,198,106,.14), 0 40px 90px rgba(0,0,0,.6);
+    background:radial-gradient(900px 620px at 50% 42%, #101830, #080d19 70%)}
+
+  .lights{position:absolute;top:16px;left:16px;display:flex;gap:8px;z-index:5}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block;background:#2a3049}
+
+  /* corners */
+  .corner{position:absolute;z-index:5;font:560 11.5px var(--mono);color:var(--faint)}
+  .corner.tl{top:52px;left:28px}
+  .corner.tr{top:20px;right:28px;text-align:right}
+  .corner b{color:var(--dim);font-weight:620}
+  .beneath{display:flex;gap:5px;align-items:center;margin-top:6px}
+  .beneath i{width:26px;height:5px;border-radius:3px;background:rgba(90,162,255,.35)}
+  .beneath i:first-child{background:rgba(90,162,255,.7)}
+
+  /* the one thing */
+  .now{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:0 130px}
+  .now .whisper-ctx{font:560 12px var(--mono);color:var(--faint);letter-spacing:.14em;text-transform:uppercase;margin-bottom:26px}
+  .now .whisper-ctx b{color:var(--green)}
+  .now h2{font-size:52px;line-height:1.12;font-weight:680;letter-spacing:-.02em;max-width:820px}
+  .now .since{margin-top:30px;font:520 13px var(--mono);color:var(--dim)}
+  .now .since b{color:var(--text)}
+  .breath{margin-top:18px;width:180px;height:3px;border-radius:2px;background:rgba(255,255,255,.07);position:relative;overflow:hidden}
+  .breath i{position:absolute;left:0;top:0;bottom:0;width:58%;border-radius:2px;background:linear-gradient(90deg,rgba(46,198,106,.2),var(--green))}
+  .now .lastnote{margin-top:34px;font:450 14px var(--mono);color:#9aa3b8;max-width:560px}
+  .now .lastnote span{color:var(--faint)}
+
+  /* gesture verbs */
+  .verb{position:absolute;z-index:5;font:600 11px var(--mono);letter-spacing:.16em;color:var(--faint);display:flex;align-items:center;gap:8px}
+  .verb kbd{border:1px solid var(--line);border-radius:5px;padding:2px 7px;color:var(--dim);font-size:10px}
+  .verb.up{top:20px;left:50%;transform:translateX(-50%)}
+  .verb.down{bottom:74px;left:50%;transform:translateX(-50%)}
+  .verb.left{left:24px;top:50%;transform:rotate(-90deg) translateX(0);transform-origin:left center}
+  .verb.up b{color:var(--green)} .verb.down b{color:var(--orange)} .verb.left b{color:var(--blue)}
+
+  /* previous card peeking left -->
+  <!-- (peek strips) */
+  .peek-l{position:absolute;left:-6px;top:32%;height:36%;width:14px;border-radius:0 10px 10px 0;
+    background:linear-gradient(90deg,rgba(90,162,255,.5),rgba(90,162,255,.08));box-shadow:0 0 24px rgba(90,162,255,.25)}
+  .peek-l small{position:absolute;left:20px;top:50%;transform:translateY(-50%);font:560 10.5px var(--mono);color:var(--faint);white-space:nowrap;writing-mode:vertical-rl}
+
+  /* later tray -->
+  <!-- semi-open film strip on the right */
+  .tray{position:absolute;right:0;top:0;bottom:0;width:216px;z-index:6;
+    background:linear-gradient(270deg,rgba(6,9,17,.97) 78%,transparent);padding:64px 18px 20px;display:flex;flex-direction:column;gap:12px}
+  .tray b.cap{font:650 10px var(--mono);letter-spacing:.22em;color:var(--faint)}
+  .mini{border:1px solid var(--line2);border-radius:11px;background:linear-gradient(170deg,#141c31,#0e1526);padding:11px 13px}
+  .mini .t{font-size:12.5px;font-weight:580;color:#c9d0e0;line-height:1.3}
+  .mini .m{font:500 10px var(--mono);color:var(--faint);margin-top:5px}
+  .mini.dim{opacity:.6}
+  .tray .hint{margin-top:auto;font:500 10.5px var(--mono);color:var(--faint)}
+  .tray .hint kbd{border:1px solid var(--line);border-radius:4px;padding:1px 5px;color:var(--dim)}
+
+  /* thought line */
+  .thought{position:absolute;left:50%;bottom:22px;transform:translateX(-50%);z-index:5;
+    width:520px;display:flex;gap:10px;align-items:center;border-bottom:1px solid rgba(255,255,255,.16);padding:8px 6px;
+    font:450 13.5px var(--mono);color:var(--faint)}
+  .thought .p{color:var(--green);font-weight:700}
+
+  .pin{position:absolute;z-index:9;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,var(--orange),var(--rose));color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+
+  .legend{max-width:1240px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,var(--orange),var(--rose));
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1240px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}.now h2{font-size:34px}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Ground-up Rethinks · Concept B of 4</div>
+<h1>FLOW / <span class="g">ONE</span></h1>
+<p class="sub">The opposite of a dashboard. The app shows exactly one thing: what you are doing right now, in type big enough to steer by. Everything else is off-screen on purpose — a list is a place you <i>visit</i>, never a place you <i>live</i>.</p>
+
+<div class="stage">
+  <div class="pin" style="top:270px;left:50%;transform:translateX(-50%)">1</div>
+  <div class="pin" style="top:70px;left:150px">2</div>
+  <div class="pin" style="top:120px;right:230px">3</div>
+  <div class="pin" style="top:400px;left:60px">4</div>
+  <div class="pin" style="bottom:120px;left:50%;transform:translateX(-64px)">5</div>
+  <div class="pin" style="bottom:60px;right:340px">6</div>
+
+  <div class="window">
+    <div class="lights"><i></i><i></i><i></i></div>
+
+    <div class="corner tl">
+      <b>improving AIDX</b> · component-library
+      <div class="beneath"><i></i><i></i></div>
+    </div>
+
+    <div class="verb up"><b>↑</b> DONE <kbd>⌘↵</kbd></div>
+    <div class="verb down"><b>↓</b> SET ASIDE <kbd>⌘⎋</kbd></div>
+    <div class="verb left"><b>→</b> TANGENT <kbd>⌘T</kbd></div>
+
+    <div class="peek-l"><small>← improving AIDX waits underneath</small></div>
+
+    <div class="now">
+      <div class="whisper-ctx"><b>●</b>&nbsp; now · 23 min</div>
+      <h2>Answer support ticket #482 — the token refresh bug</h2>
+      <div class="since">began <b>13:41</b> · third card today</div>
+      <div class="breath"><i></i></div>
+      <div class="lastnote">"need to check auth flow" <span>— your last thought, 14:02</span></div>
+    </div>
+
+    <div class="tray">
+      <b class="cap">LATER · 4</b>
+      <div class="mini"><div class="t">wear os sync</div><div class="m">set aside 3h ago</div></div>
+      <div class="mini"><div class="t">reading article</div><div class="m">set aside tue</div></div>
+      <div class="mini dim"><div class="t">component library docs</div><div class="m">yesterday</div></div>
+      <div class="mini dim"><div class="t">plan v0.0.6</div><div class="m">someday · no guilt</div></div>
+      <div class="hint"><kbd>⌘L</kbd> open later · slides over, never stays</div>
+    </div>
+
+    <div class="thought"><span class="p">›</span> think out loud — it sticks to this card…</div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>One card, teleprompter-sized.</b> The current intention is rendered like a road sign, not a row in a table. Glancing at the second monitor answers "what am I doing?" from across the room. If the type feels too big, that's the point — it makes half-hearted multitasking physically uncomfortable.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>Depth without a tree.</b> The top-left corner shows what this card sits inside — the bars are the stack, two deep. That's all the hierarchy this app will ever show you at once.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Three verbs total.</b> Done (up), set aside (down), tangent (right). Every gesture animates the card physically off-screen in that direction, so your hands learn the grammar in a day. There is deliberately no "edit" — cards are intentions, not documents.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>The interrupted card haunts the edge.</b> When you take a tangent, the parent doesn't vanish into a list — it stays as a glowing sliver on the left edge, physically <i>underneath</i>. Finishing the tangent slides the parent back in. Unclosed loops are visible as geometry, not badge counts.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>The breath bar, not a timer.</b> A soft fill that swells over the first ~25 minutes and then just glows. It never counts down, never buzzes. It exists so that "how long have I been here?" has an ambient answer instead of an anxious one.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Thoughts stick to the card.</b> One underline input. Whatever you type is stamped onto the current card with a timestamp — the card accumulates a margin of your thinking, which becomes tomorrow's re-entry ramp. The "later" tray (right) slides over on ⌘L and closes on its own; it cannot be pinned open.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · GROUND-UP RETHINKS — <a href="01-desk.html">A · Desk</a> · next: <a href="03-dialogue.html">C · Dialogue</a> · <a href="04-garden.html">D · Garden</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/2-metaphor-concepts/03-dialogue.html
+++ b/docs/ux/exploration/2-metaphor-concepts/03-dialogue.html
@@ -32,9 +32,9 @@
     box-shadow:0 40px 90px rgba(0,0,0,.6);
     background:linear-gradient(175deg,#0b1120,#080c17)}
   .titlebar{height:44px;flex:none;display:flex;align-items:center;gap:14px;padding:0 16px;border-bottom:1px solid var(--line)}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .tb{flex:1;text-align:center;font:560 12.5px var(--mono);color:var(--dim)}
   .tb b{color:var(--text)}
   .day-chips{display:flex;gap:6px}

--- a/docs/ux/exploration/2-metaphor-concepts/03-dialogue.html
+++ b/docs/ux/exploration/2-metaphor-concepts/03-dialogue.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Rethinks — C · Dialogue</title>
+<style>
+  :root{
+    --bg0:#050507; --bg1:#0a1020; --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --text:#e8ecf6; --dim:#8b93a7; --faint:#5a627a;
+    --orange:#ffaa40; --rose:#f43f5e; --violet:#a78bfa; --blue:#5aa2ff; --green:#2ec66a;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:
+      radial-gradient(1100px 500px at 15% -10%, rgba(167,139,250,.10), transparent 60%),
+      radial-gradient(900px 500px at 90% 0%, rgba(255,170,64,.07), transparent 55%),
+      linear-gradient(160deg,var(--bg0),var(--bg1));
+    color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px;
+  }
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:720px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:900px;margin:0 auto}
+  .window{border-radius:14px;overflow:hidden;height:760px;display:flex;flex-direction:column;
+    border:1px solid var(--line2);
+    box-shadow:0 40px 90px rgba(0,0,0,.6);
+    background:linear-gradient(175deg,#0b1120,#080c17)}
+  .titlebar{height:44px;flex:none;display:flex;align-items:center;gap:14px;padding:0 16px;border-bottom:1px solid var(--line)}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .tb{flex:1;text-align:center;font:560 12.5px var(--mono);color:var(--dim)}
+  .tb b{color:var(--text)}
+  .day-chips{display:flex;gap:6px}
+  .day-chips span{font:600 10px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:999px;padding:3px 9px}
+
+  .chat{flex:1;overflow:hidden;padding:22px 26px 10px;display:flex;flex-direction:column;gap:14px}
+  .tstamp{text-align:center;font:600 10px var(--mono);letter-spacing:.2em;color:var(--faint)}
+
+  .msg{max-width:72%;border-radius:16px;padding:11px 15px;font-size:13.5px;line-height:1.5;position:relative}
+  .me{align-self:flex-end;background:linear-gradient(135deg,rgba(90,162,255,.22),rgba(90,162,255,.12));
+    border:1px solid rgba(90,162,255,.28);border-bottom-right-radius:5px;color:#dbe6fa}
+  .me .t{font:500 9.5px var(--mono);color:rgba(219,230,250,.5);text-align:right;margin-top:4px}
+  .flow{align-self:flex-start;background:rgba(255,255,255,.035);border:1px solid var(--line);
+    border-bottom-left-radius:5px;color:#c3cbdc}
+  .flow::before{content:"≋";position:absolute;left:-26px;top:10px;color:var(--faint);font-size:14px}
+  .flow .t{font:500 9.5px var(--mono);color:var(--faint);margin-top:4px}
+
+  /* structured card inside a flow message */
+  .scard{margin-top:9px;border:1px solid rgba(46,198,106,.3);background:rgba(46,198,106,.06);border-radius:11px;padding:10px 13px}
+  .scard .row{display:flex;align-items:center;gap:9px;font:600 12.5px var(--mono);color:#dffbe9}
+  .scard .row i{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
+  .scard .sub2{font:500 10.5px var(--mono);color:var(--dim);margin-top:4px;padding-left:16px}
+  .scard.amber{border-color:rgba(255,170,64,.3);background:rgba(255,170,64,.05)}
+  .scard.amber .row{color:#ffe3b8}
+  .scard.amber .row i{background:var(--orange);box-shadow:none}
+
+  .chips{display:flex;gap:7px;margin-top:9px;flex-wrap:wrap}
+  .chip{font:600 11px var(--mono);color:var(--blue);border:1px solid rgba(90,162,255,.35);border-radius:999px;padding:4px 11px;background:rgba(90,162,255,.06)}
+  .chip.g{color:var(--green);border-color:rgba(46,198,106,.4);background:rgba(46,198,106,.06)}
+  .chip.dim{color:var(--faint);border-color:var(--line)}
+
+  .composer{flex:none;margin:10px 20px 18px;display:flex;align-items:center;gap:12px;
+    border:1px solid rgba(90,162,255,.3);border-radius:14px;background:rgba(8,13,26,.9);padding:13px 16px}
+  .composer .p{font:700 14px var(--mono);color:var(--blue)}
+  .composer .ph{flex:1;font:450 13.5px var(--mono);color:var(--faint)}
+  .composer .mic{color:var(--faint);font-size:15px}
+
+  .pin{position:absolute;z-index:9;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,var(--orange),var(--rose));color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+
+  .legend{max-width:1100px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,var(--orange),var(--rose));
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1100px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Ground-up Rethinks · Concept C of 4</div>
+<h1>FLOW / <span class="g">DIALOGUE</span></h1>
+<p class="sub">What if working memory were someone you talk to? No structure to maintain, no buttons to learn — you narrate your day in plain language and Flow structures it quietly, answering like a colleague who never forgets and never judges.</p>
+
+<div class="stage">
+  <div class="pin" style="top:150px;right:-13px">1</div>
+  <div class="pin" style="top:236px;left:-13px">2</div>
+  <div class="pin" style="top:420px;left:-13px">3</div>
+  <div class="pin" style="top:560px;right:-13px">4</div>
+  <div class="pin" style="bottom:26px;left:-13px">5</div>
+
+  <div class="window">
+    <div class="titlebar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <div class="tb">≋ flow — <b>thursday, with you since 09:12</b></div>
+      <div class="day-chips"><span>3 focuses</span><span>26 thoughts</span></div>
+    </div>
+
+    <div class="chat">
+      <div class="tstamp">MORNING</div>
+
+      <div class="msg flow">Good morning. Yesterday you left <b>reading article</b> half-read and parked — want it back, or shall I let it rest?
+        <div class="chips"><span class="chip">bring it back</span><span class="chip dim">let it rest</span></div>
+        <div class="t">09:07</div>
+      </div>
+
+      <div class="msg me">ok diving into the AIDX scoring problem<div class="t">09:12</div></div>
+
+      <div class="msg flow">
+        <div class="scard"><div class="row"><i></i> AIDX scoring problem</div><div class="sub2">new focus · picked up repo component-library, branch feature/aidx from your shell</div></div>
+        <div class="t">09:12</div>
+      </div>
+
+      <div class="msg me">the sample rate might be wrong for long sessions, check the decay window<div class="t">11:20</div></div>
+
+      <div class="tstamp">AFTERNOON</div>
+
+      <div class="msg me">ugh, support ticket 482 just came in, token refresh is 401ing. looking at it<div class="t">13:41</div></div>
+
+      <div class="msg flow">
+        Noted — I'll hold your place.
+        <div class="scard amber"><div class="row"><i></i> AIDX scoring problem — on hold at "check the decay window"</div><div class="sub2">4h 29m of attention banked · I'll offer it back when #482 closes</div></div>
+        <div class="scard"><div class="row"><i></i> ticket #482 · token refresh 401</div><div class="sub2">side-quest of AIDX scoring · started 13:41</div></div>
+        <div class="t">13:41</div>
+      </div>
+
+      <div class="msg me">need to check auth flow<div class="t">14:02</div></div>
+
+      <div class="msg flow">Stamped onto <b>#482</b>. You've said "auth flow" three times this week — across two different focuses. Want me to gather those thoughts into one place?
+        <div class="chips"><span class="chip g">yes, gather them</span><span class="chip dim">not now</span></div>
+        <div class="t">14:02</div>
+      </div>
+    </div>
+
+    <div class="composer"><span class="p">›</span><span class="ph">tell me what's happening…</span><span class="mic">🎙</span></div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Zero commands, zero forms.</b> "ok diving into the AIDX scoring problem" — that's the whole interaction. Flow parses intent (new focus? aside? done?) and shows its understanding as a small structured card you can tap to correct. The card is the confirmation; you never re-enter anything.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>It answers like a colleague, not a bot.</b> Short, warm, factual. When you get interrupted it says the one thing an interrupted person needs to hear: <i>"I'll hold your place"</i> — and shows exactly where the bookmark went, with the attention you'd banked.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>The transcript is the database.</b> There is no other UI. Scrolling up *is* the history view; the morning is literally above the afternoon. Structure (focuses, side-quests, holds) lives inside the conversation as cards, so re-reading your day takes thirty seconds.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>It notices, gently.</b> Because everything passes through one stream, Flow can spot patterns — "you've said 'auth flow' three times this week" — and offer to gather threads. Offers are chips, never actions taken on your behalf. Decline once and it drops the subject.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>Talk or type.</b> One composer, plus a mic for the moments your hands are mid-keystroke somewhere else. A global shortcut summons just the composer as a floating strip — the conversation catches up next time you open the window.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · GROUND-UP RETHINKS — <a href="01-desk.html">A · Desk</a> · <a href="02-one.html">B · One</a> · next: <a href="04-garden.html">D · Garden</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/2-metaphor-concepts/04-garden.html
+++ b/docs/ux/exploration/2-metaphor-concepts/04-garden.html
@@ -33,9 +33,9 @@
     background:linear-gradient(180deg,#070b16 0%,#0a1122 52%,#0d1424 64%,#080c17 64.2%,#05070d 100%)}
 
   .bar{position:absolute;top:0;left:0;right:0;height:44px;display:flex;align-items:center;gap:14px;padding:0 16px;z-index:8}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .bar .where{font:560 12px var(--mono);color:var(--faint)}
   .bar .right{margin-left:auto;display:flex;gap:8px}
   .wchip{font:600 10.5px var(--mono);color:var(--dim);border:1px solid var(--line);border-radius:999px;padding:4px 11px}

--- a/docs/ux/exploration/2-metaphor-concepts/04-garden.html
+++ b/docs/ux/exploration/2-metaphor-concepts/04-garden.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Rethinks — D · The Garden</title>
+<style>
+  :root{
+    --bg0:#050507; --bg1:#0a1020; --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --text:#e8ecf6; --dim:#8b93a7; --faint:#5a627a;
+    --orange:#ffaa40; --rose:#f43f5e; --violet:#a78bfa; --blue:#5aa2ff; --green:#2ec66a;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono","Cascadia Code",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    background:
+      radial-gradient(1100px 500px at 15% -10%, rgba(167,139,250,.10), transparent 60%),
+      radial-gradient(900px 500px at 90% 0%, rgba(255,170,64,.07), transparent 55%),
+      linear-gradient(160deg,var(--bg0),var(--bg1));
+    color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px;
+  }
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,var(--orange),var(--rose),var(--violet));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:720px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:1240px;margin:0 auto}
+  .window{position:relative;border-radius:14px;overflow:hidden;height:740px;
+    border:1px solid var(--line2);
+    box-shadow:0 40px 90px rgba(0,0,0,.6);
+    background:linear-gradient(180deg,#070b16 0%,#0a1122 52%,#0d1424 64%,#080c17 64.2%,#05070d 100%)}
+
+  .bar{position:absolute;top:0;left:0;right:0;height:44px;display:flex;align-items:center;gap:14px;padding:0 16px;z-index:8}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .bar .where{font:560 12px var(--mono);color:var(--faint)}
+  .bar .right{margin-left:auto;display:flex;gap:8px}
+  .wchip{font:600 10.5px var(--mono);color:var(--dim);border:1px solid var(--line);border-radius:999px;padding:4px 11px}
+  .wchip b{color:var(--text)}
+  .seasons{display:flex;border:1px solid var(--line);border-radius:8px;overflow:hidden;font:600 10.5px var(--mono)}
+  .seasons span{padding:4px 11px;color:var(--faint)}
+  .seasons .on{background:rgba(255,255,255,.06);color:var(--text)}
+
+  .tip{position:absolute;left:352px;top:168px;width:220px;background:rgba(11,16,30,.97);z-index:7;
+    border:1px solid rgba(90,162,255,.35);border-radius:10px;padding:9px 12px;
+    box-shadow:0 14px 34px rgba(0,0,0,.6)}
+  .tip .t{font:450 12px var(--mono);color:#c7cddc}
+  .tip .m{font:500 10px var(--mono);color:var(--faint);margin-top:4px}
+
+  .water{position:absolute;left:50%;bottom:20px;transform:translateX(-50%);z-index:8;
+    display:flex;align-items:center;gap:10px;width:480px;border:1px solid rgba(46,198,106,.3);border-radius:999px;
+    background:rgba(8,13,26,.92);padding:10px 18px;font:450 13px var(--mono);color:var(--faint)}
+  .water .p{color:var(--green);font-weight:700}
+
+  .pin{position:absolute;z-index:9;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,var(--orange),var(--rose));color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+
+  .legend{max-width:1240px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,var(--orange),var(--rose));
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1240px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Ground-up Rethinks · Concept D of 4</div>
+<h1>FLOW / <span class="g">GARDEN</span></h1>
+<p class="sub">Work as something alive. Every focus is a plant: attention is water, thoughts are dew, tangents are literal branches. Neglected work wilts — visibly, kindly — and finished work blossoms and is carried to the meadow. You don't manage this garden. You <i>tend</i> it.</p>
+
+<div class="stage">
+  <div class="pin" style="top:250px;left:170px">1</div>
+  <div class="pin" style="top:130px;left:530px">4</div>
+  <div class="pin" style="top:330px;right:330px">2</div>
+  <div class="pin" style="top:180px;right:100px">3</div>
+  <div class="pin" style="bottom:130px;left:60px">5</div>
+  <div class="pin" style="bottom:64px;right:280px">6</div>
+
+  <div class="window">
+    <div class="bar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <span class="where">the garden · thursday, dusk</span>
+      <div class="right">
+        <span class="wchip">clear skies · <b>1 in bloom</b> · 1 thirsty</span>
+        <div class="seasons"><span class="on">day</span><span>week</span><span>season</span></div>
+      </div>
+    </div>
+
+    <!-- dew tooltip -->
+    <div class="tip"><div class="t">“need to check auth flow”</div><div class="m">dew from 14:02 · on the #482 branch</div></div>
+
+    <svg viewBox="0 0 1240 740" width="100%" height="100%" preserveAspectRatio="xMidYMid slice" aria-label="A line-art night garden where each plant is a stream of work">
+      <defs>
+        <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
+          <feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+        </filter>
+        <radialGradient id="moon" cx=".5" cy=".5" r=".5">
+          <stop offset="0%" stop-color="#ffe9c4" stop-opacity=".9"/><stop offset="100%" stop-color="#ffe9c4" stop-opacity="0"/>
+        </radialGradient>
+        <linearGradient id="soil" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#0b0f1c"/><stop offset="100%" stop-color="#04060b"/>
+        </linearGradient>
+      </defs>
+
+      <!-- sky -->
+      <circle cx="1100" cy="110" r="90" fill="url(#moon)"/>
+      <circle cx="1100" cy="110" r="26" fill="#ffe9c4" opacity=".85"/>
+      <g fill="#e8ecf6">
+        <circle cx="140" cy="90" r="1.4" opacity=".5"/><circle cx="260" cy="150" r="1.1" opacity=".35"/>
+        <circle cx="480" cy="70" r="1.3" opacity=".45"/><circle cx="700" cy="120" r="1.2" opacity=".4"/>
+        <circle cx="860" cy="70" r="1.4" opacity=".5"/><circle cx="960" cy="210" r="1.1" opacity=".3"/>
+        <circle cx="80" cy="230" r="1.2" opacity=".35"/><circle cx="590" cy="200" r="1" opacity=".3"/>
+      </g>
+
+      <!-- ground -->
+      <rect x="0" y="474" width="1240" height="266" fill="url(#soil)"/>
+      <line x1="0" y1="474" x2="1240" y2="474" stroke="rgba(255,255,255,.14)" stroke-width="1.5"/>
+
+      <!-- ═══ plant 1 · ACTIVE (green, glowing) ═══ -->
+      <g filter="url(#glow)">
+        <path d="M300 474 C295 410 312 340 300 260 C296 220 304 195 299 172" stroke="#2ec66a" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+        <!-- tangent branch -->
+        <path d="M303 330 C335 312 356 292 372 262" stroke="#5aa2ff" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+      </g>
+      <!-- leaves -->
+      <g fill="none" stroke="#2ec66a" stroke-width="2.2" stroke-linejoin="round">
+        <path d="M298 420 q -34 -16 -56 -8 q 20 24 56 14 z"/>
+        <path d="M301 372 q 34 -16 56 -8 q -20 24 -56 14 z"/>
+        <path d="M299 290 q -30 -14 -50 -7 q 18 22 50 13 z"/>
+        <path d="M299 216 q 28 -13 47 -6 q -17 20 -47 12 z"/>
+      </g>
+      <g fill="none" stroke="#5aa2ff" stroke-width="1.8">
+        <path d="M352 300 q 26 -12 42 -5 q -15 18 -42 11 z"/>
+        <path d="M372 262 q 8 -22 24 -30 q 2 22 -24 30 z"/>
+      </g>
+      <!-- dew -->
+      <circle cx="345" cy="288" r="3.2" fill="#bcd7ff"/>
+      <circle cx="299" cy="172" r="4" fill="#dffbe9"/>
+      <circle cx="255" cy="416" r="3" fill="#bcd7ff" opacity=".8"/>
+      <!-- fireflies -->
+      <circle cx="240" cy="240" r="2.4" fill="#ffe9a0" filter="url(#glow)" opacity=".9"/>
+      <circle cx="392" cy="200" r="2" fill="#ffe9a0" filter="url(#glow)" opacity=".7"/>
+      <circle cx="330" cy="140" r="1.8" fill="#ffe9a0" filter="url(#glow)" opacity=".6"/>
+
+      <!-- ═══ plant 2 · RESTING (amber, leaves folded) ═══ -->
+      <path d="M540 474 C536 430 546 390 540 340" stroke="#ffaa40" stroke-opacity=".75" stroke-width="3" fill="none" stroke-linecap="round"/>
+      <g fill="none" stroke="#ffaa40" stroke-opacity=".65" stroke-width="2">
+        <path d="M539 430 q -26 -4 -40 8 q 22 12 40 2 z"/>
+        <path d="M541 400 q 26 -4 40 8 q -22 12 -40 2 z"/>
+        <path d="M540 352 q -20 -6 -32 4 q 16 12 32 4 z"/>
+      </g>
+      <circle cx="540" cy="338" r="3" fill="#ffd9a0" opacity=".8"/>
+
+      <!-- ═══ plant 3 · SEEDLING (violet sprout) ═══ -->
+      <path d="M680 474 C679 458 682 448 680 436" stroke="#a78bfa" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+      <g fill="none" stroke="#a78bfa" stroke-width="1.8">
+        <path d="M679 446 q -16 -8 -28 -4 q 10 14 28 10 z"/>
+        <path d="M681 440 q 16 -8 28 -4 q -10 14 -28 10 z"/>
+      </g>
+
+      <!-- ═══ plant 4 · WILTING (grey, drooping) ═══ -->
+      <path d="M830 474 C826 428 838 396 832 372 C828 354 810 348 796 362 C788 370 786 380 790 388" stroke="#8b93a7" stroke-opacity=".7" stroke-width="2.8" fill="none" stroke-linecap="round"/>
+      <g fill="none" stroke="#8b93a7" stroke-opacity=".55" stroke-width="1.8">
+        <path d="M829 432 q -24 6 -34 20 q 24 4 34 -10 z"/>
+        <path d="M833 408 q 24 6 34 20 q -24 4 -34 -10 z"/>
+      </g>
+      <!-- fallen leaf -->
+      <path d="M866 468 q 18 -10 30 -4 q -12 12 -30 4 z" fill="none" stroke="#8b93a7" stroke-opacity=".4" stroke-width="1.5"/>
+
+      <!-- ═══ plant 5 · BLOSSOMED (done — rose flower) ═══ -->
+      <path d="M1010 474 C1006 420 1016 370 1010 318" stroke="#f43f5e" stroke-opacity=".8" stroke-width="3" fill="none" stroke-linecap="round"/>
+      <g filter="url(#glow)">
+        <circle cx="1010" cy="300" r="9" fill="#ffaa40"/>
+        <g fill="#f43f5e" opacity=".9">
+          <circle cx="1010" cy="281" r="8"/><circle cx="1027" cy="291" r="8"/><circle cx="1027" cy="310" r="8"/>
+          <circle cx="1010" cy="319" r="8"/><circle cx="993" cy="310" r="8"/><circle cx="993" cy="291" r="8"/>
+        </g>
+      </g>
+      <g fill="none" stroke="#f43f5e" stroke-opacity=".55" stroke-width="1.8">
+        <path d="M1009 420 q -26 -10 -42 -4 q 16 18 42 12 z"/>
+      </g>
+      <!-- drifting petals -->
+      <circle cx="1062" cy="352" r="3.5" fill="#f43f5e" opacity=".5"/>
+      <circle cx="1088" cy="398" r="3" fill="#f43f5e" opacity=".3"/>
+
+      <!-- ═══ roots (event history) ═══ -->
+      <g stroke-linecap="round" fill="none">
+        <path d="M300 474 C304 520 288 560 296 618" stroke="#2ec66a" stroke-opacity=".22" stroke-width="2"/>
+        <path d="M300 474 C280 510 270 540 262 566" stroke="#2ec66a" stroke-opacity=".14" stroke-width="1.5"/>
+        <path d="M300 474 C322 512 334 546 340 584" stroke="#2ec66a" stroke-opacity=".14" stroke-width="1.5"/>
+        <path d="M540 474 C544 508 534 534 538 560" stroke="#ffaa40" stroke-opacity=".16" stroke-width="1.5"/>
+        <path d="M680 474 C681 492 678 502 680 512" stroke="#a78bfa" stroke-opacity=".2" stroke-width="1.5"/>
+        <path d="M830 474 C834 516 824 552 830 594" stroke="#8b93a7" stroke-opacity=".15" stroke-width="1.5"/>
+        <path d="M1010 474 C1014 524 1002 566 1008 612" stroke="#f43f5e" stroke-opacity=".16" stroke-width="1.5"/>
+      </g>
+      <g fill="#e8ecf6" opacity=".35">
+        <circle cx="296" cy="520" r="1.8"/><circle cx="290" cy="560" r="1.8"/><circle cx="295" cy="600" r="1.8"/>
+        <circle cx="270" cy="540" r="1.5"/><circle cx="336" cy="566" r="1.5"/>
+        <circle cx="540" cy="530" r="1.5"/><circle cx="830" cy="540" r="1.5"/><circle cx="1009" cy="550" r="1.5"/><circle cx="1010" cy="590" r="1.5"/>
+      </g>
+
+      <!-- plaques -->
+      <g font-family="ui-monospace,Menlo,monospace">
+        <text x="300" y="500" text-anchor="middle" font-size="12" fill="#e8ecf6" font-weight="600">answering support</text>
+        <text x="300" y="516" text-anchor="middle" font-size="10" fill="#2ec66a">in bloom · watered 24m ago</text>
+        <text x="540" y="500" text-anchor="middle" font-size="12" fill="#c3cbdc" font-weight="600">improving AIDX</text>
+        <text x="540" y="516" text-anchor="middle" font-size="10" fill="#ffaa40">resting · holds your place</text>
+        <text x="680" y="500" text-anchor="middle" font-size="12" fill="#c3cbdc" font-weight="600">plan v0.0.6</text>
+        <text x="680" y="516" text-anchor="middle" font-size="10" fill="#a78bfa">seedling · just an idea</text>
+        <text x="830" y="500" text-anchor="middle" font-size="12" fill="#8b93a7" font-weight="600">reading article</text>
+        <text x="830" y="516" text-anchor="middle" font-size="10" fill="#8b93a7">thirsty · 3 days without rain</text>
+        <text x="1010" y="500" text-anchor="middle" font-size="12" fill="#e8ecf6" font-weight="600">fix release pipeline</text>
+        <text x="1010" y="516" text-anchor="middle" font-size="10" fill="#f43f5e">blossomed · off to the meadow ⟶</text>
+      </g>
+
+      <!-- meadow arrow -->
+      <text x="1180" y="452" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5a627a" text-anchor="end">the meadow ⟶</text>
+    </svg>
+
+    <div class="water"><span class="p">›</span> water a plant with a thought…</div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Attention is water.</b> The plant you're tending is the one in bloom — it glows, fireflies gather, and every thought you type lands on it as dew. Click any other plant to move the watering can; the garden allows exactly one bloom at a time.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>Wilting is information, not shame.</b> Untouched work droops by degrees — <i>thirsty</i>, then dormant, then quietly composted into the archive. A drooping plant is the softest possible nudge, and "3 days without rain" reads very differently from "OVERDUE".</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Done work blossoms.</b> Finishing something is a visible, slightly celebratory event: the plant flowers, drops petals, and drifts off to <i>the meadow</i> — a separate scene of everything you've ever completed. The meadow is the anti-backlog: a place you visit to feel good.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>Tangents are literal branches.</b> A side-quest grows as a blue offshoot of the parent stem, with its own leaves and dew. Finish it and it fuses back into the stem's growth; abandon it and just that branch wilts, never the whole plant.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>Roots are memory.</b> Below the soil line, every plant's history — each pickup, pause and thought — grows downward as roots. Old work has deep roots you can excavate by scrolling down. Nothing is ever lost; it just goes underground.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Weather and seasons.</b> The sky reflects load: clear when the garden is small, overcast when too much blooms at once. The <i>season</i> view compresses months into growth rings — your year, readable at a glance like a tree stump.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · GROUND-UP RETHINKS — <a href="01-desk.html">A · Desk</a> · <a href="02-one.html">B · One</a> · <a href="03-dialogue.html">C · Dialogue</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/2-metaphor-concepts/README.md
+++ b/docs/ux/exploration/2-metaphor-concepts/README.md
@@ -1,0 +1,59 @@
+# Liminal Flow — Ground-up Desktop Rethinks
+
+Part of the desktop exploration. Where [`1-desktop-app/`](../1-desktop-app/) — the
+chosen design — translated the existing CLI/TUI faithfully to a Tauri app, this set ignores
+the current design entirely and asks: *if a working-memory tool were born on
+the desktop, what could it be?*
+
+Four deliberately divergent product concepts. Each is a self-contained,
+annotated HTML mock-up — open in any browser.
+
+| # | Concept | Core metaphor | One-line thesis |
+|---|---------|---------------|-----------------|
+| A | [FLOW / DESK](01-desk.html) | An infinite desk under lamplight | Focus is a *place*, not a status flag — spatial memory replaces every list |
+| B | [FLOW / ONE](02-one.html) | A teleprompter for intention | Show exactly one thing, huge; three gesture verbs; lists are visited, never lived in |
+| C | [FLOW / DIALOGUE](03-dialogue.html) | A colleague you narrate your day to | Plain language in, quiet structure out — the transcript *is* the database |
+| D | [FLOW / GARDEN](04-garden.html) | A living night garden | Attention is water; neglect wilts kindly; done work blossoms into the meadow |
+
+## What the four disagree about (on purpose)
+
+- **Where structure lives.** Desk: in space. One: hidden, one card at a time.
+  Dialogue: inferred from language. Garden: in organic form (stems, branches,
+  roots).
+- **How neglect is shown.** Desk: things cool and drift off the edge. One:
+  nothing is shown at all. Dialogue: Flow mentions it, once. Garden: plants
+  visibly wilt.
+- **What "done" feels like.** Desk: a card slides off the horizon. One: a
+  satisfying upward flick. Dialogue: a sentence ("done with that"). Garden: a
+  blossom and a petal-fall.
+- **How much the tool talks back.** From silent (One) to fully conversational
+  (Dialogue).
+
+## What all four agree on
+
+1. **One active focus** — every concept enforces a single point of attention,
+   each through its own physics (the lamp, the single card, "I'll hold your
+   place", one bloom at a time).
+2. **Capture is one gesture** — a whisper bar, a thought line, a composer, a
+   watering can. Plain text, no dialogs, no forms.
+3. **Interruptions bank their context** — the parent card peeks at the edge,
+   the clip rides along, the colleague holds your place, the branch stays on
+   the stem.
+4. **No guilt mechanics** — nothing is overdue, scored, or streaked. Neglect
+   decays gracefully into an archive (the edge, the tray, the transcript, the
+   compost) instead of accusing you.
+5. **The record is free** — everything renders from the same append-only
+   event history; the user never does bookkeeping to get the picture.
+
+## Tauri feasibility notes
+
+- All four are single-webview apps; **Desk** wants a canvas/WebGL layer for
+  smooth pan-zoom, **Garden** is pure SVG with light animation.
+- **One** benefits most from Tauri niceties: compact fixed-size window,
+  `always_on_top` option, global shortcuts for its three verbs.
+- **Dialogue**'s intent parsing can start as simple verb heuristics (the
+  existing title-normalisation rules generalise) and grow into a local model;
+  the structured-card confirmations make wrong guesses cheap to correct.
+- Any of the four can still share the CLI's SQLite store — the concepts
+  discard the CLI's *interface*, not its data model. Threads, branches,
+  captures and events map cleanly onto cards, stems, holds and roots.

--- a/docs/ux/exploration/3-clean-concepts/01-queue.html
+++ b/docs/ux/exploration/3-clean-concepts/01-queue.html
@@ -26,9 +26,9 @@
     border:1px solid var(--line2);background:var(--bg);
     box-shadow:0 40px 90px rgba(0,0,0,.55)}
   .titlebar{height:42px;flex:none;display:flex;align-items:center;gap:12px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--surface)}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .tb-search{margin:0 auto;display:flex;align-items:center;gap:8px;width:380px;height:28px;border:1px solid var(--line);
     border-radius:7px;padding:0 10px;font:450 12px var(--mono);color:var(--faint);background:var(--bg)}
   .tb-search kbd{margin-left:auto;border:1px solid var(--line);border-radius:4px;padding:0 5px;font-size:10px;color:var(--faint)}
@@ -130,7 +130,7 @@
   <div class="window">
     <div class="titlebar">
       <div class="lights"><i></i><i></i><i></i></div>
-      <div class="tb-search">⌕ search everything… <kbd>⌘K</kbd></div>
+      <div class="tb-search">⌕ search everything… <kbd>Ctrl+K</kbd></div>
     </div>
 
     <div class="cols">
@@ -163,7 +163,7 @@
           </div>
         </div>
 
-        <div class="sec-h">UP NEXT <span class="n">· 4</span><span class="hint">drag or ⌘↑↓ to reorder · Enter starts the top item</span></div>
+        <div class="sec-h">UP NEXT <span class="n">· 4</span><span class="hint">drag or Ctrl+Shift+↑↓ to reorder · Enter starts the top item</span></div>
         <div class="rows">
           <div class="row sel">
             <span class="st" style="background:var(--amber)"></span><span class="t">Improving AIDX — resume at "check the decay window"</span>
@@ -229,7 +229,7 @@
   <div class="leg"><span class="n">2</span><p><b>A nav that mirrors the mental model.</b> Focus (now/queue, waiting, someday), Log (today, week, done), System. Nothing invented: every section answers a question you actually ask — "what's next?", "what am I blocked on?", "what did I do?"</p></div>
   <div class="leg"><span class="n">3</span><p><b>The queue is an order, not a backlog.</b> Items hold an explicit position — position 1 is what Enter starts next. Each held item carries its <i>re-entry point</i> ("resume at: check the decay window"), so starting is never a cold start.</p></div>
   <div class="leg"><span class="n">4</span><p><b>Inspector, not modal.</b> Selection drives the right pane: state, scope, re-entry note, sub-tasks, and the note trail. Every field is a flat row — no cards inside cards. Actions repeat at the bottom with their keys, teaching the keyboard as you click.</p></div>
-  <div class="leg"><span class="n">5</span><p><b>One input, two meanings, zero modes.</b> The command bar captures: plain text while something is selected becomes a note; plain text otherwise becomes a queue item. ⌘K opens search/commands. There is no other way to create anything — so there is nothing to learn.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>One input, two meanings, zero modes.</b> The command bar captures: plain text while something is selected becomes a note; plain text otherwise becomes a queue item. Ctrl+K opens search/commands. There is no other way to create anything — so there is nothing to learn.</p></div>
   <div class="leg"><span class="n">6</span><p><b>Waiting is a first-class state.</b> Blocked items name what they're waiting on and leave the queue entirely — they can't guilt you from position 3. A daily sweep asks about anything waiting &gt; 3 days: still blocked, or quietly done?</p></div>
 </div>
 

--- a/docs/ux/exploration/3-clean-concepts/01-queue.html
+++ b/docs/ux/exploration/3-clean-concepts/01-queue.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Clean — 1 · Queue</title>
+<style>
+  :root{
+    --bg:#0a0d14; --surface:#0e1320; --surface2:#111726; --raised:#151c2e;
+    --line:rgba(255,255,255,.07); --line2:rgba(255,255,255,.12);
+    --text:#e6eaf2; --dim:#9aa3b5; --faint:#5d6579;
+    --green:#2ec66a; --blue:#5aa2ff; --amber:#ffaa40; --violet:#a78bfa; --rose:#f43f5e;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:linear-gradient(170deg,#090c12,#0b1019);color:var(--text);
+    font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px}
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,#ffaa40,#f43f5e,#a78bfa);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:700px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:1280px;margin:0 auto}
+  .window{border-radius:12px;overflow:hidden;height:760px;display:flex;flex-direction:column;
+    border:1px solid var(--line2);background:var(--bg);
+    box-shadow:0 40px 90px rgba(0,0,0,.55)}
+  .titlebar{height:42px;flex:none;display:flex;align-items:center;gap:12px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--surface)}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .tb-search{margin:0 auto;display:flex;align-items:center;gap:8px;width:380px;height:28px;border:1px solid var(--line);
+    border-radius:7px;padding:0 10px;font:450 12px var(--mono);color:var(--faint);background:var(--bg)}
+  .tb-search kbd{margin-left:auto;border:1px solid var(--line);border-radius:4px;padding:0 5px;font-size:10px;color:var(--faint)}
+
+  .cols{flex:1;display:flex;min-height:0}
+
+  /* nav */
+  .nav{width:224px;flex:none;border-right:1px solid var(--line);background:var(--surface);padding:14px 10px;display:flex;flex-direction:column}
+  .nav .grp{font:650 10px var(--mono);letter-spacing:.18em;color:var(--faint);padding:12px 10px 6px}
+  .nav a{display:flex;align-items:center;gap:9px;padding:6px 10px;border-radius:7px;color:var(--dim);font-size:13px;text-decoration:none}
+  .nav a .ic{width:16px;text-align:center;font-size:12px;color:var(--faint)}
+  .nav a .ct{margin-left:auto;font:600 11px var(--mono);color:var(--faint)}
+  .nav a.on{background:var(--raised);color:var(--text)}
+  .nav a.on .ic{color:var(--green)}
+  .nav .foot{margin-top:auto;padding:10px;border-top:1px solid var(--line);font:500 11px var(--mono);color:var(--faint)}
+  .nav .foot b{color:var(--dim)}
+
+  /* list */
+  .list{flex:1;min-width:0;display:flex;flex-direction:column;background:var(--bg)}
+  .now-block{flex:none;margin:14px 16px 6px;border:1px solid rgba(46,198,106,.35);border-radius:10px;background:var(--surface2)}
+  .now-head{display:flex;align-items:center;gap:9px;padding:10px 14px;border-bottom:1px solid var(--line)}
+  .now-head .dot{width:8px;height:8px;border-radius:50%;background:var(--green)}
+  .now-head b{font:650 10.5px var(--mono);letter-spacing:.16em;color:var(--green)}
+  .now-head time{margin-left:auto;font:600 12px var(--mono);color:var(--dim)}
+  .now-body{display:flex;align-items:center;gap:14px;padding:12px 14px}
+  .now-body .t{font-size:15px;font-weight:620}
+  .now-body .scope{font:500 11px var(--mono);color:var(--faint)}
+  .now-acts{margin-left:auto;display:flex;gap:6px}
+  .a-btn{font:600 11.5px var(--mono);color:var(--dim);border:1px solid var(--line2);border-radius:7px;padding:5px 11px;background:transparent}
+  .a-btn.g{color:var(--green);border-color:rgba(46,198,106,.4)}
+
+  .sec-h{display:flex;align-items:center;gap:8px;padding:16px 22px 6px;font:650 10.5px var(--mono);letter-spacing:.16em;color:var(--faint)}
+  .sec-h .n{color:var(--dim)}
+  .sec-h .hint{margin-left:auto;font-weight:500;letter-spacing:0;text-transform:none}
+  .rows{padding:0 16px}
+  .row{display:flex;align-items:center;gap:12px;height:40px;padding:0 10px;border-radius:8px;border:1px solid transparent}
+  .row:hover{background:var(--surface2)}
+  .row.sel{background:var(--surface2);border-color:rgba(90,162,255,.4)}
+  .row .st{width:8px;height:8px;border-radius:50%;flex:none}
+  .row .t{font-size:13.5px;color:#cdd3e0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .row .chip{font:500 10.5px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:5px;padding:1px 7px;flex:none}
+  .row .age{margin-left:auto;font:500 11px var(--mono);color:var(--faint);flex:none}
+  .row .h{display:flex;gap:4px;flex:none}
+  .row .h kbd{font:600 9.5px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:4px;padding:1px 5px;opacity:0}
+  .row.sel .h kbd{opacity:1}
+  .row.dim2{opacity:.55}
+
+  /* inspector */
+  .insp{width:336px;flex:none;border-left:1px solid var(--line);background:var(--surface);display:flex;flex-direction:column}
+  .insp-h{padding:16px 18px 12px;border-bottom:1px solid var(--line)}
+  .insp-h .t{font-size:15px;font-weight:630}
+  .insp-h .sub2{font:500 11px var(--mono);color:var(--faint);margin-top:4px}
+  .field{display:flex;align-items:center;padding:9px 18px;border-bottom:1px solid var(--line);font-size:12.5px}
+  .field .k{width:86px;color:var(--faint);font:500 11px var(--mono)}
+  .field .v{color:var(--dim)}
+  .field .v.sel2{border:1px solid var(--line2);border-radius:6px;padding:2px 9px;color:var(--amber);font:600 11px var(--mono)}
+  .insp .notes{flex:1;overflow:hidden;padding:12px 18px}
+  .insp .notes b{font:650 10px var(--mono);letter-spacing:.16em;color:var(--faint)}
+  .n-item{display:flex;gap:10px;padding:8px 0;border-bottom:1px solid var(--line)}
+  .n-item time{font:500 10.5px var(--mono);color:var(--faint);flex:none;padding-top:1px}
+  .n-item p{font-size:12.5px;color:#b9c1d2}
+  .insp-f{padding:12px 16px;border-top:1px solid var(--line);display:flex;gap:6px}
+  .insp-f .a-btn{flex:1;text-align:center}
+
+  /* command bar */
+  .cmdbar{flex:none;height:44px;border-top:1px solid var(--line);background:var(--surface);display:flex;align-items:center;gap:12px;padding:0 18px;font:450 12.5px var(--mono);color:var(--faint)}
+  .cmdbar .p{color:var(--blue);font-weight:700}
+  .cmdbar .keys{margin-left:auto;display:flex;gap:14px;font-size:11px}
+  .cmdbar kbd{border:1px solid var(--line);border-radius:4px;padding:0 5px;color:var(--dim)}
+
+  .pin{position:absolute;z-index:9;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,#ffaa40,#f43f5e);color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+  .legend{max-width:1280px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,#ffaa40,#f43f5e);
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1280px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Ground-up Rethinks · Series 3 (Clean) · 1 of 4</div>
+<h1>FLOW / <span class="g">QUEUE</span></h1>
+<p class="sub">An operator's console for attention. Three panes, zero decoration: a fixed <b style="color:var(--text)">Now</b> block, an ordered queue beneath it, an inspector on the right. Every action is a single key. The design goal is boring excellence — Linear's discipline applied to working memory.</p>
+
+<div class="stage">
+  <div class="pin" style="top:170px;left:340px">1</div>
+  <div class="pin" style="top:120px;left:-13px">2</div>
+  <div class="pin" style="top:330px;left:480px">3</div>
+  <div class="pin" style="top:250px;right:-13px">4</div>
+  <div class="pin" style="bottom:26px;left:420px">5</div>
+  <div class="pin" style="top:520px;left:340px">6</div>
+
+  <div class="window">
+    <div class="titlebar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <div class="tb-search">⌕ search everything… <kbd>⌘K</kbd></div>
+    </div>
+
+    <div class="cols">
+      <!-- nav -->
+      <div class="nav">
+        <div class="grp">FOCUS</div>
+        <a class="on" href="#"><span class="ic">●</span> Now &amp; queue <span class="ct">5</span></a>
+        <a href="#"><span class="ic">◱</span> Waiting on <span class="ct">2</span></a>
+        <a href="#"><span class="ic">◌</span> Someday <span class="ct">7</span></a>
+        <div class="grp">LOG</div>
+        <a href="#"><span class="ic">▤</span> Today</a>
+        <a href="#"><span class="ic">▦</span> This week</a>
+        <a href="#"><span class="ic">✓</span> Done <span class="ct">31</span></a>
+        <div class="grp">SYSTEM</div>
+        <a href="#"><span class="ic">◫</span> Archive</a>
+        <a href="#"><span class="ic">⚙</span> Settings</a>
+        <div class="foot">focused today <b>3h 12m</b><br>switches <b>3</b></div>
+      </div>
+
+      <!-- list -->
+      <div class="list">
+        <div class="now-block">
+          <div class="now-head"><span class="dot"></span><b>NOW</b><time>23:41 elapsed</time></div>
+          <div class="now-body">
+            <div>
+              <div class="t">Answer support ticket #482 — token refresh bug</div>
+              <div class="scope">component-library · feature/aidx · sub-task of "Improving AIDX"</div>
+            </div>
+            <div class="now-acts"><span class="a-btn g">✓ Done</span><span class="a-btn">Set aside</span><span class="a-btn">Sub-task</span></div>
+          </div>
+        </div>
+
+        <div class="sec-h">UP NEXT <span class="n">· 4</span><span class="hint">drag or ⌘↑↓ to reorder · Enter starts the top item</span></div>
+        <div class="rows">
+          <div class="row sel">
+            <span class="st" style="background:var(--amber)"></span><span class="t">Improving AIDX — resume at "check the decay window"</span>
+            <span class="chip">component-library</span><span class="age">held 1h</span>
+            <div class="h"><kbd>↵ start</kbd><kbd>n note</kbd><kbd>w wait</kbd></div>
+          </div>
+          <div class="row">
+            <span class="st" style="background:var(--amber)"></span><span class="t">Wear OS sync — battery drain repro</span>
+            <span class="chip">wear-companion</span><span class="age">3h</span><div class="h"></div>
+          </div>
+          <div class="row">
+            <span class="st" style="background:var(--faint)"></span><span class="t">Component library docs — props tables</span>
+            <span class="chip">component-library</span><span class="age">1d</span><div class="h"></div>
+          </div>
+          <div class="row dim2">
+            <span class="st" style="background:var(--faint)"></span><span class="t">Plan v0.0.6 scope</span>
+            <span class="chip">flow</span><span class="age">2d</span><div class="h"></div>
+          </div>
+        </div>
+
+        <div class="sec-h">WAITING ON <span class="n">· 2</span></div>
+        <div class="rows">
+          <div class="row dim2">
+            <span class="st" style="background:var(--violet)"></span><span class="t">Release sign-off — waiting on Dana's review</span>
+            <span class="chip">flow</span><span class="age">since tue</span><div class="h"></div>
+          </div>
+          <div class="row dim2">
+            <span class="st" style="background:var(--violet)"></span><span class="t">API quota bump — waiting on support reply</span>
+            <span class="chip">infra</span><span class="age">since mon</span><div class="h"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- inspector -->
+      <div class="insp">
+        <div class="insp-h">
+          <div class="t">Improving AIDX</div>
+          <div class="sub2">created mon 09:12 · 4h 29m attention total</div>
+        </div>
+        <div class="field"><span class="k">STATE</span><span class="v sel2">HELD · position 1</span></div>
+        <div class="field"><span class="k">SCOPE</span><span class="v">component-library · feature/aidx</span></div>
+        <div class="field"><span class="k">RE-ENTRY</span><span class="v">"check the decay window"</span></div>
+        <div class="field"><span class="k">SUB-TASKS</span><span class="v">1 active (#482) · 1 done</span></div>
+        <div class="notes">
+          <b>NOTES · 6</b>
+          <div class="n-item"><time>11:20</time><p>sample rate might be wrong for long sessions, check decay window</p></div>
+          <div class="n-item"><time>10:02</time><p>scoring feels off above ~40 min — collect three traces</p></div>
+          <div class="n-item"><time>09:15</time><p>baseline: current AIDX on the nightly corpus = 0.61</p></div>
+        </div>
+        <div class="insp-f"><span class="a-btn g">↵ Start now</span><span class="a-btn">n Add note</span><span class="a-btn">⇧A Archive</span></div>
+      </div>
+    </div>
+
+    <div class="cmdbar">
+      <span class="p">›</span> add to queue, or type a note for the current focus…
+      <div class="keys"><span><kbd>↵</kbd> capture</span><span><kbd>j/k</kbd> move</span><span><kbd>1–9</kbd> jump</span><span><kbd>?</kbd> keys</span></div>
+    </div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Now is furniture, not a row.</b> The active focus is a fixed block above the list — visually a different species from queue items, so "what am I doing" and "what's next" can never blur. Its three verbs (done, set aside, sub-task) are the only buttons in the main pane.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>A nav that mirrors the mental model.</b> Focus (now/queue, waiting, someday), Log (today, week, done), System. Nothing invented: every section answers a question you actually ask — "what's next?", "what am I blocked on?", "what did I do?"</p></div>
+  <div class="leg"><span class="n">3</span><p><b>The queue is an order, not a backlog.</b> Items hold an explicit position — position 1 is what Enter starts next. Each held item carries its <i>re-entry point</i> ("resume at: check the decay window"), so starting is never a cold start.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>Inspector, not modal.</b> Selection drives the right pane: state, scope, re-entry note, sub-tasks, and the note trail. Every field is a flat row — no cards inside cards. Actions repeat at the bottom with their keys, teaching the keyboard as you click.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>One input, two meanings, zero modes.</b> The command bar captures: plain text while something is selected becomes a note; plain text otherwise becomes a queue item. ⌘K opens search/commands. There is no other way to create anything — so there is nothing to learn.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Waiting is a first-class state.</b> Blocked items name what they're waiting on and leave the queue entirely — they can't guilt you from position 3. A daily sweep asks about anything waiting &gt; 3 days: still blocked, or quietly done?</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · CLEAN SERIES — next: <a href="02-day.html">2 · Day</a> · <a href="03-board.html">3 · Board</a> · <a href="04-review.html">4 · Review</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/3-clean-concepts/02-day.html
+++ b/docs/ux/exploration/3-clean-concepts/02-day.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Clean — 2 · Day</title>
+<style>
+  :root{
+    --bg:#0a0d14; --surface:#0e1320; --surface2:#111726; --raised:#151c2e;
+    --line:rgba(255,255,255,.07); --line2:rgba(255,255,255,.12);
+    --text:#e6eaf2; --dim:#9aa3b5; --faint:#5d6579;
+    --green:#2ec66a; --blue:#5aa2ff; --amber:#ffaa40; --violet:#a78bfa; --rose:#f43f5e;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:linear-gradient(170deg,#090c12,#0b1019);color:var(--text);
+    font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px}
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,#ffaa40,#f43f5e,#a78bfa);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:700px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:1280px;margin:0 auto}
+  .window{border-radius:12px;overflow:hidden;height:780px;display:flex;flex-direction:column;
+    border:1px solid var(--line2);background:var(--bg);box-shadow:0 40px 90px rgba(0,0,0,.55)}
+  .titlebar{height:42px;flex:none;display:flex;align-items:center;gap:12px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--surface)}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .datebar{margin:0 auto;display:flex;align-items:center;gap:14px;font:600 13px var(--mono)}
+  .datebar .arr{color:var(--faint);border:1px solid var(--line);border-radius:6px;width:24px;height:24px;display:grid;place-items:center;font-size:12px}
+  .seg{display:flex;border:1px solid var(--line);border-radius:7px;overflow:hidden;font:600 11px var(--mono)}
+  .seg span{padding:4px 12px;color:var(--faint)}
+  .seg .on{background:var(--raised);color:var(--text)}
+  .total{font:600 11px var(--mono);color:var(--dim)}
+  .total b{color:var(--green)}
+
+  .cols{flex:1;display:flex;min-height:0}
+
+  /* timeline */
+  .tl{flex:1;min-width:0;position:relative;padding:18px 26px 18px 0;background:var(--bg)}
+  .canvas{position:absolute;left:76px;right:26px;top:24px;bottom:56px}
+  .hour{position:absolute;left:-58px;font:500 10.5px var(--mono);color:var(--faint);transform:translateY(-50%)}
+  .hline{position:absolute;left:0;right:0;height:1px;background:var(--line)}
+  .block{position:absolute;left:0;right:34%;border-radius:8px;background:var(--surface2);
+    border:1px solid var(--line2);border-left:3px solid var(--blue);padding:7px 12px;overflow:hidden}
+  .block .t{font-size:12.5px;font-weight:600;color:#d4dae6;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .block .m{font:500 10px var(--mono);color:var(--faint)}
+  .block.small{padding:4px 12px}
+  .block.small .t{font-size:11.5px}
+  .block.orange{border-left-color:var(--amber)}
+  .block.live{border-color:rgba(46,198,106,.45);border-left-color:var(--green);background:#0f1a24}
+  .block.live .t{color:#e6eaf2}
+  .block .dots{position:absolute;right:10px;top:8px;display:flex;gap:4px}
+  .block .dots i{width:5px;height:5px;border-radius:50%;background:var(--faint)}
+  .block.sel{outline:2px solid rgba(90,162,255,.5)}
+  .gap-label{position:absolute;left:0;right:34%;text-align:center;font:500 10.5px var(--mono);color:var(--faint)}
+  .nowline{position:absolute;left:-8px;right:30%;height:2px;background:var(--green);border-radius:1px}
+  .nowline::before{content:"";position:absolute;left:-4px;top:-3px;width:8px;height:8px;border-radius:50%;background:var(--green)}
+  .nowline b{position:absolute;right:-58px;top:-7px;font:700 10px var(--mono);color:var(--green)}
+
+  /* right panel */
+  .side{width:392px;flex:none;border-left:1px solid var(--line);background:var(--surface);display:flex;flex-direction:column;min-height:0}
+  .p-sec{padding:16px 20px;border-bottom:1px solid var(--line)}
+  .p-sec .cap{font:650 10px var(--mono);letter-spacing:.18em;color:var(--faint);margin-bottom:9px;display:flex}
+  .p-sec .cap .r{margin-left:auto;font-weight:500;letter-spacing:0}
+  .nowcard{border:1px solid rgba(46,198,106,.35);border-radius:10px;background:var(--surface2);padding:12px 14px}
+  .nowcard .r1{display:flex;align-items:center;gap:9px}
+  .nowcard .dot{width:8px;height:8px;border-radius:50%;background:var(--green)}
+  .nowcard .t{font-size:14px;font-weight:620}
+  .nowcard time{margin-left:auto;font:600 11.5px var(--mono);color:var(--dim)}
+  .nowcard .m{font:500 11px var(--mono);color:var(--faint);margin-top:5px;padding-left:17px}
+  .blk-notes .n-item{display:flex;gap:10px;padding:7px 0;border-bottom:1px solid var(--line)}
+  .blk-notes .n-item:last-child{border-bottom:none}
+  .blk-notes time{font:500 10.5px var(--mono);color:var(--faint);flex:none;padding-top:1px}
+  .blk-notes p{font-size:12.5px;color:#b9c1d2}
+  .later{flex:1;overflow:hidden}
+  .l-item{display:flex;align-items:center;gap:10px;padding:8px 0;border-bottom:1px solid var(--line);font-size:13px;color:var(--dim)}
+  .l-item .st{width:7px;height:7px;border-radius:50%;background:var(--amber);flex:none}
+  .l-item .age{margin-left:auto;font:500 10.5px var(--mono);color:var(--faint)}
+  .l-item kbd{font:600 9.5px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:4px;padding:1px 5px}
+  .capbar{flex:none;margin:14px 16px 16px;display:flex;align-items:center;gap:10px;border:1px solid var(--line2);
+    border-radius:9px;background:var(--bg);padding:10px 14px;font:450 12.5px var(--mono);color:var(--faint)}
+  .capbar .p{color:var(--blue);font-weight:700}
+
+  .pin{position:absolute;z-index:9;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,#ffaa40,#f43f5e);color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+  .legend{max-width:1280px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,#ffaa40,#f43f5e);
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1280px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Ground-up Rethinks · Series 3 (Clean) · 2 of 4</div>
+<h1>FLOW / <span class="g">DAY</span></h1>
+<p class="sub">A calendar that fills itself in. The day column is not a plan — it's a faithful record of where your attention actually went, drawn as blocks while you work. You read it the way you read a calendar, but backwards: not "what's next?" — <b style="color:var(--text)">"what happened?"</b></p>
+
+<div class="stage">
+  <div class="pin" style="top:180px;left:280px">1</div>
+  <div class="pin" style="top:388px;left:530px">2</div>
+  <div class="pin" style="top:498px;left:280px">3</div>
+  <div class="pin" style="top:130px;right:-13px">4</div>
+  <div class="pin" style="top:360px;right:-13px">5</div>
+  <div class="pin" style="bottom:40px;right:180px">6</div>
+
+  <div class="window">
+    <div class="titlebar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <div class="datebar">
+        <span class="arr">‹</span> Today · Thu Aug 14 <span class="arr">›</span>
+        <div class="seg"><span class="on">day</span><span>week</span></div>
+        <span class="total">recorded <b>3h 12m</b> across 3 focuses</span>
+      </div>
+    </div>
+
+    <div class="cols">
+      <!-- timeline -->
+      <div class="tl">
+        <div class="canvas">
+          <!-- hour grid: 09:00 → 18:00 over 100% -->
+          <div class="hline" style="top:0%"></div><span class="hour" style="top:0%">09:00</span>
+          <div class="hline" style="top:11.1%"></div><span class="hour" style="top:11.1%">10:00</span>
+          <div class="hline" style="top:22.2%"></div><span class="hour" style="top:22.2%">11:00</span>
+          <div class="hline" style="top:33.3%"></div><span class="hour" style="top:33.3%">12:00</span>
+          <div class="hline" style="top:44.4%"></div><span class="hour" style="top:44.4%">13:00</span>
+          <div class="hline" style="top:55.6%"></div><span class="hour" style="top:55.6%">14:00</span>
+          <div class="hline" style="top:66.7%"></div><span class="hour" style="top:66.7%">15:00</span>
+          <div class="hline" style="top:77.8%"></div><span class="hour" style="top:77.8%">16:00</span>
+          <div class="hline" style="top:88.9%"></div><span class="hour" style="top:88.9%">17:00</span>
+          <div class="hline" style="top:100%"></div><span class="hour" style="top:100%">18:00</span>
+
+          <!-- blocks -->
+          <div class="block" style="top:2.2%;height:14%">
+            <div class="t">Improving AIDX</div><div class="m">09:12 – 10:40 · 1h 28m · 3 notes</div>
+            <div class="dots"><i></i><i></i><i></i></div>
+          </div>
+          <div class="block small orange" style="top:16.6%;height:4.2%">
+            <div class="t">Wear OS sync — battery repro <span style="color:var(--faint);font-weight:500">· 25m</span></div>
+          </div>
+          <div class="block" style="top:21.2%;height:15.5%">
+            <div class="t">Improving AIDX</div><div class="m">11:05 – 12:30 · 1h 25m · 1 note</div>
+            <div class="dots"><i></i></div>
+          </div>
+          <div class="gap-label" style="top:38.5%">— away 35m · nothing recorded, nothing invented —</div>
+          <div class="block sel" style="top:41.5%;height:6.2%">
+            <div class="t">Improving AIDX</div><div class="m">13:05 – 13:41 · 36m</div>
+          </div>
+          <div class="block live" style="top:48.2%;height:8.2%">
+            <div class="t">Support ticket #482 — token refresh bug</div>
+            <div class="m">13:41 – now · 45m · sub-task of Improving AIDX</div>
+          </div>
+          <div class="nowline" style="top:56.6%"><b>14:26</b></div>
+        </div>
+      </div>
+
+      <!-- right panel -->
+      <div class="side">
+        <div class="p-sec">
+          <div class="cap">NOW</div>
+          <div class="nowcard">
+            <div class="r1"><span class="dot"></span><span class="t">Support ticket #482</span><time>45m</time></div>
+            <div class="m">component-library · feature/aidx · will return to Improving AIDX</div>
+          </div>
+        </div>
+        <div class="p-sec blk-notes">
+          <div class="cap">SELECTED BLOCK · 13:05 – 13:41 <span class="r">Improving AIDX</span></div>
+          <div class="n-item"><time>13:09</time><p>decay window is hardcoded at 30m — that's the bug</p></div>
+          <div class="n-item"><time>13:38</time><p>fix sketched; needs a test with a 90m synthetic session</p></div>
+        </div>
+        <div class="p-sec later">
+          <div class="cap">NOT YET TODAY <span class="r">order = queue</span></div>
+          <div class="l-item"><span class="st"></span> Improving AIDX — resume at decay-window test <span class="age">next</span><kbd>↵</kbd></div>
+          <div class="l-item"><span class="st"></span> Component library docs <span class="age">1d</span></div>
+          <div class="l-item"><span class="st" style="background:var(--violet)"></span> Release sign-off — waiting on Dana <span class="age">tue</span></div>
+        </div>
+        <div class="capbar"><span class="p">›</span> note lands on the current block…</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Blocks are recorded, never planned.</b> A block appears when you start a focus and grows while you stay. The day column is append-only history in calendar clothing — familiar to read, impossible to fall behind on, because there is nothing to fill in.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>Gaps are kept, labelled, and neutral.</b> Time away is drawn as honest whitespace — "nothing recorded, nothing invented." No app-filling, no shame red. The record stays trustworthy precisely because it admits what it doesn't know.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Interruptions read as geology.</b> The morning shows AIDX split by a 25-minute Wear OS interlude — three strata instead of one lie about "3 hours of AIDX." Sub-tasks (the live green block) carry their parentage in the subtitle, so the story stays legible.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>The right panel answers three questions.</b> Now (what's running), Selected block (what was I thinking then — click any block to replay its notes), and Not-yet-today (the queue, in order). Fixed sections, no tabs, no rearranging.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>Notes are pinned to time × block.</b> Every note lands on the block that was running when you wrote it. Clicking 13:05–13:41 shows exactly the two thoughts from that half hour — "what was I thinking before lunch?" becomes a click, not an archaeology dig.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Week view is the same data, folded.</b> Seven day-columns side by side, blocks coloured by focus. Because it's all recorded, the week view doubles as a truthful timesheet — export it, or just stop guessing on Friday.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · CLEAN SERIES — <a href="01-queue.html">1 · Queue</a> · next: <a href="03-board.html">3 · Board</a> · <a href="04-review.html">4 · Review</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/3-clean-concepts/02-day.html
+++ b/docs/ux/exploration/3-clean-concepts/02-day.html
@@ -25,9 +25,9 @@
   .window{border-radius:12px;overflow:hidden;height:780px;display:flex;flex-direction:column;
     border:1px solid var(--line2);background:var(--bg);box-shadow:0 40px 90px rgba(0,0,0,.55)}
   .titlebar{height:42px;flex:none;display:flex;align-items:center;gap:12px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--surface)}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .datebar{margin:0 auto;display:flex;align-items:center;gap:14px;font:600 13px var(--mono)}
   .datebar .arr{color:var(--faint);border:1px solid var(--line);border-radius:6px;width:24px;height:24px;display:grid;place-items:center;font-size:12px}
   .seg{display:flex;border:1px solid var(--line);border-radius:7px;overflow:hidden;font:600 11px var(--mono)}

--- a/docs/ux/exploration/3-clean-concepts/03-board.html
+++ b/docs/ux/exploration/3-clean-concepts/03-board.html
@@ -25,9 +25,9 @@
   .window{border-radius:12px;overflow:hidden;height:740px;display:flex;flex-direction:column;
     border:1px solid var(--line2);background:var(--bg);box-shadow:0 40px 90px rgba(0,0,0,.55)}
   .titlebar{height:42px;flex:none;display:flex;align-items:center;gap:12px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--surface)}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .tb-mid{margin:0 auto;font:600 12.5px var(--mono);color:var(--dim)}
   .tb-mid b{color:var(--text)}
   .tb-right{font:600 11px var(--mono);color:var(--faint)}
@@ -202,7 +202,7 @@
 
     <div class="capbar">
       <span class="p">›</span> new card lands at the bottom of Next…
-      <div class="keys"><span><kbd>↵</kbd> add</span><span><kbd>⌘↵</kbd> add &amp; start (swaps Now)</span><span><kbd>1–4</kbd> jump column</span></div>
+      <div class="keys"><span><kbd>↵</kbd> add</span><span><kbd>Ctrl+↵</kbd> add &amp; start (swaps Now)</span><span><kbd>1–4</kbd> jump column</span></div>
     </div>
   </div>
 </div>
@@ -213,7 +213,7 @@
   <div class="leg"><span class="n">3</span><p><b>Next is ordered and capped.</b> Five slots, numbered. When a sixth card arrives, the board asks which one drops to Someday. The cap converts "backlog anxiety" into a small, concrete decision made at add-time instead of a pile read at review-time.</p></div>
   <div class="leg"><span class="n">4</span><p><b>Waiting names its blocker.</b> Every card in Waiting must say what it's waiting on — a person, a reply, a build. Cards age visibly (2d, 3d) and a stale card prompts one question at day-start: nudge, drop, or still blocked?</p></div>
   <div class="leg"><span class="n">5</span><p><b>Done resets at midnight.</b> The column is a today-sized win list, not an archive — three finishes, timestamps, gone tomorrow. History lives in the log; the board only ever shows a day you can act on.</p></div>
-  <div class="leg"><span class="n">6</span><p><b>Capture is one line, placement is automatic.</b> Plain text becomes a card at the bottom of Next; ⌘↵ starts it immediately via the same explicit swap. No card editor, no fields — a title and a scope picked up from context are enough to start.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Capture is one line, placement is automatic.</b> Plain text becomes a card at the bottom of Next; Ctrl+↵ starts it immediately via the same explicit swap. No card editor, no fields — a title and a scope picked up from context are enough to start.</p></div>
 </div>
 
 <div class="foot">LIMINAL FLOW · CLEAN SERIES — <a href="01-queue.html">1 · Queue</a> · <a href="02-day.html">2 · Day</a> · next: <a href="04-review.html">4 · Review</a></div>

--- a/docs/ux/exploration/3-clean-concepts/03-board.html
+++ b/docs/ux/exploration/3-clean-concepts/03-board.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Clean — 3 · Board</title>
+<style>
+  :root{
+    --bg:#0a0d14; --surface:#0e1320; --surface2:#111726; --raised:#151c2e;
+    --line:rgba(255,255,255,.07); --line2:rgba(255,255,255,.12);
+    --text:#e6eaf2; --dim:#9aa3b5; --faint:#5d6579;
+    --green:#2ec66a; --blue:#5aa2ff; --amber:#ffaa40; --violet:#a78bfa; --rose:#f43f5e;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:linear-gradient(170deg,#090c12,#0b1019);color:var(--text);
+    font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px}
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,#ffaa40,#f43f5e,#a78bfa);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:720px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:1280px;margin:0 auto}
+  .window{border-radius:12px;overflow:hidden;height:740px;display:flex;flex-direction:column;
+    border:1px solid var(--line2);background:var(--bg);box-shadow:0 40px 90px rgba(0,0,0,.55)}
+  .titlebar{height:42px;flex:none;display:flex;align-items:center;gap:12px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--surface)}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .tb-mid{margin:0 auto;font:600 12.5px var(--mono);color:var(--dim)}
+  .tb-mid b{color:var(--text)}
+  .tb-right{font:600 11px var(--mono);color:var(--faint)}
+
+  .board{flex:1;display:flex;gap:14px;padding:18px 18px 8px;min-height:0}
+  .col{flex:1;min-width:0;display:flex;flex-direction:column;border:1px solid var(--line);border-radius:12px;background:var(--surface);min-height:0}
+  .col.now{flex:1.35;border-color:rgba(46,198,106,.35)}
+  .col-h{flex:none;display:flex;align-items:center;gap:9px;padding:12px 15px;border-bottom:1px solid var(--line)}
+  .col-h b{font:650 11px var(--mono);letter-spacing:.16em;color:var(--dim)}
+  .col.now .col-h b{color:var(--green)}
+  .col-h .wip{margin-left:auto;font:600 10.5px var(--mono);color:var(--faint);border:1px solid var(--line);border-radius:999px;padding:2px 9px}
+  .col-h .wip.full{color:var(--green);border-color:rgba(46,198,106,.4)}
+  .col-h .wip.over{color:var(--amber);border-color:rgba(255,170,64,.4)}
+  .col-b{flex:1;overflow:hidden;padding:12px;display:flex;flex-direction:column;gap:10px}
+
+  .card{border:1px solid var(--line2);border-radius:10px;background:var(--surface2);padding:11px 13px}
+  .card .t{font-size:13px;font-weight:600;color:#d4dae6;line-height:1.35}
+  .card .m{display:flex;gap:8px;align-items:center;margin-top:7px;font:500 10.5px var(--mono);color:var(--faint)}
+  .card .m .chip{border:1px solid var(--line);border-radius:5px;padding:1px 7px}
+  .card .m .age{margin-left:auto}
+  .card .reentry{margin-top:8px;font:450 11px var(--mono);color:var(--dim);border-left:2px solid var(--blue);padding:2px 0 2px 8px}
+  .card.pos::before{content:attr(data-pos);float:right;font:700 10px var(--mono);color:var(--faint);
+    border:1px solid var(--line);border-radius:5px;padding:1px 6px;margin-left:8px}
+  .card.wait{border-left:3px solid var(--violet)}
+  .card.wait .who{color:var(--violet)}
+  .card.donec{opacity:.75;padding:8px 13px}
+  .card.donec .t{font-size:12px;color:var(--dim);font-weight:500}
+  .card.donec .t::before{content:"✓ ";color:var(--green);font-weight:700}
+  .card.donec .m{margin-top:3px}
+
+  /* the NOW card */
+  .bigcard{border:1px solid rgba(46,198,106,.4);border-radius:10px;background:#0f1a24;padding:14px 15px;display:flex;flex-direction:column;flex:1;max-height:320px}
+  .bigcard .r1{display:flex;align-items:center;gap:9px}
+  .bigcard .dot{width:8px;height:8px;border-radius:50%;background:var(--green)}
+  .bigcard time{margin-left:auto;font:650 12px var(--mono);color:var(--green)}
+  .bigcard .t{font-size:15.5px;font-weight:640;margin-top:8px;line-height:1.35}
+  .bigcard .sc{font:500 11px var(--mono);color:var(--faint);margin-top:6px}
+  .bigcard .notes{margin-top:12px;border-top:1px solid var(--line);padding-top:9px;flex:1;overflow:hidden}
+  .bigcard .notes .cap{font:650 9.5px var(--mono);letter-spacing:.16em;color:var(--faint)}
+  .bigcard .n{display:flex;gap:9px;padding:6px 0;font-size:12px;color:#b9c1d2}
+  .bigcard .n time{margin-left:0;font:500 10px var(--mono);color:var(--faint);flex:none;padding-top:1px}
+  .bigcard .acts{display:flex;gap:7px;margin-top:10px}
+  .a-btn{font:600 11.5px var(--mono);color:var(--dim);border:1px solid var(--line2);border-radius:7px;padding:6px 0;flex:1;text-align:center}
+  .a-btn.g{color:var(--green);border-color:rgba(46,198,106,.4)}
+
+  /* drag rejection vignette */
+  .ghost{position:absolute;left:404px;top:262px;width:230px;z-index:7;transform:rotate(-3deg);
+    border:1px solid rgba(255,170,64,.5);border-radius:10px;background:rgba(17,23,38,.95);padding:11px 13px;
+    box-shadow:0 18px 40px rgba(0,0,0,.6)}
+  .ghost .t{font-size:13px;font-weight:600;color:#d4dae6}
+  .ghost .m{font:500 10.5px var(--mono);color:var(--faint);margin-top:5px}
+  .toast{position:absolute;left:388px;top:352px;z-index:7;width:262px;border:1px solid rgba(255,170,64,.4);
+    border-radius:9px;background:#171308;padding:9px 12px;font:500 11.5px var(--mono);color:#ffd9a0}
+  .toast b{color:#ffe9c4}
+
+  .capbar{flex:none;margin:8px 18px 16px;display:flex;align-items:center;gap:10px;border:1px solid var(--line2);
+    border-radius:9px;background:var(--surface);padding:11px 14px;font:450 12.5px var(--mono);color:var(--faint)}
+  .capbar .p{color:var(--blue);font-weight:700}
+  .capbar .keys{margin-left:auto;display:flex;gap:12px;font-size:11px}
+  .capbar kbd{border:1px solid var(--line);border-radius:4px;padding:0 5px;color:var(--dim)}
+
+  .pin{position:absolute;z-index:9;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,#ffaa40,#f43f5e);color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+  .legend{max-width:1280px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,#ffaa40,#f43f5e);
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1280px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Ground-up Rethinks · Series 3 (Clean) · 3 of 4</div>
+<h1>FLOW / <span class="g">BOARD</span></h1>
+<p class="sub">Personal kanban with teeth. Four fixed columns — <b style="color:var(--text)">Now, Next, Waiting, Done today</b> — and one non-negotiable rule: Now holds exactly one card. The board doesn't advise the limit; it <i>enforces</i> it.</p>
+
+<div class="stage">
+  <div class="pin" style="top:120px;left:150px">1</div>
+  <div class="pin" style="top:392px;left:352px">2</div>
+  <div class="pin" style="top:120px;left:49%">3</div>
+  <div class="pin" style="top:120px;right:300px">4</div>
+  <div class="pin" style="top:120px;right:20px">5</div>
+  <div class="pin" style="bottom:34px;left:50%;transform:translateX(-50%)">6</div>
+
+  <div class="window">
+    <div class="titlebar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <div class="tb-mid">board · <b>thursday</b></div>
+      <div class="tb-right">3h 12m focused · 3 finishes</div>
+    </div>
+
+    <div class="board">
+      <!-- NOW -->
+      <div class="col now">
+        <div class="col-h"><b>NOW</b><span class="wip full">1 / 1</span></div>
+        <div class="col-b">
+          <div class="bigcard">
+            <div class="r1"><span class="dot"></span><span style="font:650 10px var(--mono);letter-spacing:.14em;color:var(--green)">IN FOCUS</span><time>45:12</time></div>
+            <div class="t">Support ticket #482 — token refresh bug</div>
+            <div class="sc">component-library · feature/aidx · sub-task of Improving AIDX</div>
+            <div class="notes">
+              <div class="cap">CARD NOTES</div>
+              <div class="n"><time>14:02</time>need to check auth flow</div>
+              <div class="n"><time>13:47</time>401s only after &gt;30 min idle — decay window suspect</div>
+            </div>
+            <div class="acts"><span class="a-btn g">✓ Done</span><span class="a-btn">→ Next</span><span class="a-btn">◱ Waiting</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- NEXT -->
+      <div class="col">
+        <div class="col-h"><b>NEXT</b><span class="wip">4 / 5</span></div>
+        <div class="col-b">
+          <div class="card pos" data-pos="1">
+            <div class="t">Improving AIDX</div>
+            <div class="reentry">resume at: test decay-window fix, 90m synthetic session</div>
+            <div class="m"><span class="chip">component-library</span><span class="age">held 45m</span></div>
+          </div>
+          <div class="card pos" data-pos="2">
+            <div class="t">Wear OS sync — battery drain repro</div>
+            <div class="m"><span class="chip">wear-companion</span><span class="age">3h</span></div>
+          </div>
+          <div class="card pos" data-pos="3">
+            <div class="t">Component library docs — props tables</div>
+            <div class="m"><span class="chip">component-library</span><span class="age">1d</span></div>
+          </div>
+          <div class="card pos" data-pos="4">
+            <div class="t">Plan v0.0.6 scope</div>
+            <div class="m"><span class="chip">flow</span><span class="age">2d</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- WAITING -->
+      <div class="col">
+        <div class="col-h"><b>WAITING</b><span class="wip">2</span></div>
+        <div class="col-b">
+          <div class="card wait">
+            <div class="t">Release sign-off</div>
+            <div class="m"><span class="who">◱ Dana's review</span><span class="age">2d</span></div>
+          </div>
+          <div class="card wait">
+            <div class="t">API quota bump</div>
+            <div class="m"><span class="who">◱ support reply</span><span class="age">3d</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DONE -->
+      <div class="col">
+        <div class="col-h"><b>DONE TODAY</b><span class="wip">3</span></div>
+        <div class="col-b">
+          <div class="card donec"><div class="t">Fix release pipeline</div><div class="m"><span class="age">09:50</span></div></div>
+          <div class="card donec"><div class="t">Triage #479, #480</div><div class="m"><span class="age">09:05</span></div></div>
+          <div class="card donec"><div class="t">AIDX baseline measured — 0.61</div><div class="m"><span class="age">10:12</span></div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- drag rejection -->
+    <div class="ghost">
+      <div class="t">Wear OS sync — battery drain repro</div>
+      <div class="m">dragging toward NOW…</div>
+    </div>
+    <div class="toast"><b>Now is full.</b> Drop to swap — #482 moves to Next, position 1, with its re-entry note attached.</div>
+
+    <div class="capbar">
+      <span class="p">›</span> new card lands at the bottom of Next…
+      <div class="keys"><span><kbd>↵</kbd> add</span><span><kbd>⌘↵</kbd> add &amp; start (swaps Now)</span><span><kbd>1–4</kbd> jump column</span></div>
+    </div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Now is a column of one.</b> The active card is rendered large, with its live timer and note trail — it's the only card on the board that shows content, because it's the only card you should be reading. WIP limit 1/1 is displayed like a law, not a preference.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>The swap is explicit and fair.</b> Dragging a second card onto Now doesn't stack it — the board explains the trade: the current card moves to Next position 1 and keeps its re-entry note. Context switching is allowed; <i>unaccounted</i> context switching is not.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Next is ordered and capped.</b> Five slots, numbered. When a sixth card arrives, the board asks which one drops to Someday. The cap converts "backlog anxiety" into a small, concrete decision made at add-time instead of a pile read at review-time.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>Waiting names its blocker.</b> Every card in Waiting must say what it's waiting on — a person, a reply, a build. Cards age visibly (2d, 3d) and a stale card prompts one question at day-start: nudge, drop, or still blocked?</p></div>
+  <div class="leg"><span class="n">5</span><p><b>Done resets at midnight.</b> The column is a today-sized win list, not an archive — three finishes, timestamps, gone tomorrow. History lives in the log; the board only ever shows a day you can act on.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Capture is one line, placement is automatic.</b> Plain text becomes a card at the bottom of Next; ⌘↵ starts it immediately via the same explicit swap. No card editor, no fields — a title and a scope picked up from context are enough to start.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · CLEAN SERIES — <a href="01-queue.html">1 · Queue</a> · <a href="02-day.html">2 · Day</a> · next: <a href="04-review.html">4 · Review</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/3-clean-concepts/04-review.html
+++ b/docs/ux/exploration/3-clean-concepts/04-review.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Flow Clean — 4 · Review</title>
+<style>
+  :root{
+    --bg:#0a0d14; --surface:#0e1320; --surface2:#111726; --raised:#151c2e;
+    --line:rgba(255,255,255,.07); --line2:rgba(255,255,255,.12);
+    --text:#e6eaf2; --dim:#9aa3b5; --faint:#5d6579;
+    --green:#2ec66a; --blue:#5aa2ff; --amber:#ffaa40; --violet:#a78bfa; --rose:#f43f5e;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono",Menlo,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:linear-gradient(170deg,#090c12,#0b1019);color:var(--text);
+    font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;
+    min-height:100vh;padding:48px 24px 80px}
+  .kicker{font:600 11px/1 var(--mono);letter-spacing:.22em;text-transform:uppercase;color:var(--faint);text-align:center}
+  h1{text-align:center;font-size:26px;font-weight:650;margin:10px 0 4px}
+  h1 .g{background:linear-gradient(90deg,#ffaa40,#f43f5e,#a78bfa);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{text-align:center;color:var(--dim);max-width:720px;margin:0 auto 40px;font-size:14px}
+
+  .stage{position:relative;max-width:1280px;margin:0 auto}
+  .window{border-radius:12px;overflow:hidden;height:800px;display:flex;flex-direction:column;
+    border:1px solid var(--line2);background:var(--bg);box-shadow:0 40px 90px rgba(0,0,0,.55)}
+  .titlebar{height:42px;flex:none;display:flex;align-items:center;gap:12px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--surface)}
+  .lights{display:flex;gap:8px}
+  .lights i{width:12px;height:12px;border-radius:50%;display:block}
+  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .weekpick{margin:0 auto;display:flex;align-items:center;gap:12px;font:600 13px var(--mono)}
+  .weekpick .arr{color:var(--faint);border:1px solid var(--line);border-radius:6px;width:24px;height:24px;display:grid;place-items:center;font-size:12px}
+  .tb-right{font:600 11px var(--mono);color:var(--faint)}
+
+  .body{flex:1;min-height:0;padding:16px 18px;display:flex;flex-direction:column;gap:14px;overflow:hidden}
+
+  /* stat tiles */
+  .tiles{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;flex:none}
+  .tile{border:1px solid var(--line);border-radius:11px;background:var(--surface);padding:13px 16px}
+  .tile .k{font:600 10px var(--mono);letter-spacing:.16em;color:var(--faint)}
+  .tile .v{font:650 24px/1.2 var(--mono);color:var(--text);margin-top:5px;letter-spacing:-.02em}
+  .tile .d{font:500 11px var(--mono);color:var(--dim);margin-top:3px}
+  .tile .d .up{color:var(--green)}
+  .tile .d .warn{color:var(--amber)}
+
+  .mid{flex:1;display:flex;gap:14px;min-height:0}
+  .panel{border:1px solid var(--line);border-radius:11px;background:var(--surface);display:flex;flex-direction:column;min-height:0}
+  .panel .ph{flex:none;display:flex;align-items:baseline;gap:10px;padding:13px 16px 9px}
+  .panel .ph b{font:650 10.5px var(--mono);letter-spacing:.16em;color:var(--dim)}
+  .panel .ph .r{margin-left:auto;font:500 10.5px var(--mono);color:var(--faint)}
+
+  /* heatmap */
+  .heatwrap{width:472px;flex:none}
+  .heat{padding:2px 16px 8px}
+  .hrow{display:flex;align-items:center;gap:4px;margin-bottom:4px}
+  .hrow .day{width:34px;font:500 10px var(--mono);color:var(--faint)}
+  .cell{width:40px;height:26px;border-radius:4px;background:var(--surface2)}
+  .haxis{display:flex;gap:4px;padding-left:38px;margin-bottom:6px}
+  .haxis span{width:40px;font:500 9.5px var(--mono);color:var(--faint);text-align:left}
+  .hleg{display:flex;align-items:center;gap:7px;padding:8px 16px 12px;font:500 10px var(--mono);color:var(--faint)}
+  .hleg i{width:16px;height:9px;border-radius:2px}
+  .cell.q1{background:rgba(90,162,255,.10)} .cell.q2{background:rgba(90,162,255,.26)}
+  .cell.q3{background:rgba(90,162,255,.48)} .cell.q4{background:rgba(90,162,255,.78)}
+  .cell.hov{outline:2px solid #cfe2ff;outline-offset:1px}
+  .heattip{position:absolute;left:315px;top:308px;z-index:7;background:#151c2e;border:1px solid var(--line2);
+    border-radius:8px;padding:7px 11px;font:500 11px var(--mono);color:var(--dim);box-shadow:0 12px 30px rgba(0,0,0,.5)}
+  .heattip b{color:var(--text)}
+
+  /* narrative */
+  .narr{padding:4px 16px 14px;font-size:12.5px;color:var(--dim);line-height:1.6;border-top:1px solid var(--line);margin-top:auto}
+  .narr b{color:var(--text);font-weight:620}
+
+  /* sessions table */
+  .sess{flex:1;min-width:0}
+  table{width:100%;border-collapse:collapse}
+  th{font:650 9.5px var(--mono);letter-spacing:.14em;color:var(--faint);text-align:left;padding:6px 16px;border-bottom:1px solid var(--line)}
+  th.num,td.num{text-align:right}
+  td{padding:7px 16px;border-bottom:1px solid var(--line);font-size:12.5px;color:#c3cbdc;white-space:nowrap}
+  td .mark{display:inline-block;width:7px;height:7px;border-radius:2px;background:var(--faint);margin-right:8px;vertical-align:0}
+  td.num{font:500 11.5px var(--mono);color:var(--dim)}
+  .durbar{display:inline-block;height:8px;border-radius:2px 4px 4px 2px;background:var(--blue);vertical-align:0;margin-right:8px}
+  tr.best td{background:rgba(90,162,255,.05)}
+  tr.best td:first-child{border-left:2px solid var(--blue)}
+
+  /* loose ends */
+  .loose{flex:none;border:1px solid rgba(255,170,64,.25);border-radius:11px;background:var(--surface)}
+  .loose .ph b{color:var(--amber)}
+  .l-row{display:flex;align-items:center;gap:12px;padding:8px 16px;border-top:1px solid var(--line);font-size:12.5px}
+  .l-row .st{width:7px;height:7px;border-radius:50%;flex:none}
+  .l-row .t{color:#c3cbdc}
+  .l-row .why{font:500 10.5px var(--mono);color:var(--faint)}
+  .l-row .acts{margin-left:auto;display:flex;gap:6px}
+  .l-row .a{font:600 10.5px var(--mono);border:1px solid var(--line2);border-radius:6px;padding:3px 10px;color:var(--dim)}
+  .l-row .a.g{color:var(--green);border-color:rgba(46,198,106,.35)}
+
+  .pin{position:absolute;z-index:9;width:26px;height:26px;border-radius:50%;
+    background:linear-gradient(135deg,#ffaa40,#f43f5e);color:#14060a;
+    font:800 13px var(--mono);display:grid;place-items:center;box-shadow:0 4px 14px rgba(244,63,94,.45)}
+  .legend{max-width:1280px;margin:34px auto 0;display:grid;grid-template-columns:repeat(2,1fr);gap:12px 28px}
+  .leg{display:flex;gap:12px;align-items:flex-start}
+  .leg .n{flex:none;width:22px;height:22px;border-radius:50%;background:linear-gradient(135deg,#ffaa40,#f43f5e);
+    color:#14060a;font:800 11.5px var(--mono);display:grid;place-items:center;margin-top:2px}
+  .leg p{font-size:13px;color:var(--dim)}
+  .leg p b{color:var(--text);font-weight:620}
+  .foot{max-width:1280px;margin:40px auto 0;text-align:center;font:500 11.5px var(--mono);color:var(--faint)}
+  .foot a{color:var(--blue);text-decoration:none}
+  @media (max-width:900px){.legend{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<div class="kicker">Liminal Flow · Ground-up Rethinks · Series 3 (Clean) · 4 of 4</div>
+<h1>FLOW / <span class="g">REVIEW</span></h1>
+<p class="sub">The weekly close. Not a dashboard you stare at daily — a console you open on Friday to read the week honestly: where attention went, what the deepest work was, and which loose ends deserve a decision before Monday.</p>
+
+<div class="stage">
+  <div class="pin" style="top:100px;left:180px">1</div>
+  <div class="pin" style="top:230px;left:-13px">2</div>
+  <div class="pin" style="top:230px;right:-13px">3</div>
+  <div class="pin" style="top:470px;left:340px">4</div>
+  <div class="pin" style="bottom:120px;left:-13px">5</div>
+  <div class="pin" style="bottom:200px;right:300px">6</div>
+
+  <div class="window">
+    <div class="titlebar">
+      <div class="lights"><i></i><i></i><i></i></div>
+      <div class="weekpick"><span class="arr">‹</span> Week 33 · Aug 11 – 15 <span class="arr">›</span></div>
+      <div class="tb-right">⌘E export · read-only</div>
+    </div>
+
+    <div class="body">
+      <!-- stat tiles -->
+      <div class="tiles">
+        <div class="tile"><div class="k">FOCUSED TIME</div><div class="v">14h 36m</div><div class="d"><span class="up">▲ 1h 40m</span> vs last week</div></div>
+        <div class="tile"><div class="k">DEEPEST SESSION</div><div class="v">1h 28m</div><div class="d">Improving AIDX · tue 09:12</div></div>
+        <div class="tile"><div class="k">SWITCHES / DAY</div><div class="v">3.2</div><div class="d"><span class="up">▼ 0.8</span> — calmer than last week</div></div>
+        <div class="tile"><div class="k">LOOSE ENDS</div><div class="v">3</div><div class="d"><span class="warn">2 need a decision</span></div></div>
+      </div>
+
+      <div class="mid">
+        <!-- heatmap -->
+        <div class="panel heatwrap">
+          <div class="ph"><b>FOCUS BY HOUR</b><span class="r">minutes recorded per hour</span></div>
+          <div class="heat">
+            <div class="haxis"><span>09</span><span>10</span><span>11</span><span>12</span><span>13</span><span>14</span><span>15</span><span>16</span><span>17</span></div>
+            <div class="hrow"><span class="day">MON</span><span class="cell q3"></span><span class="cell q4"></span><span class="cell q2"></span><span class="cell"></span><span class="cell q1"></span><span class="cell q3"></span><span class="cell q3"></span><span class="cell q1"></span><span class="cell"></span></div>
+            <div class="hrow"><span class="day">TUE</span><span class="cell q4"></span><span class="cell q4"></span><span class="cell q3"></span><span class="cell q1"></span><span class="cell"></span><span class="cell q2"></span><span class="cell q4"></span><span class="cell q2"></span><span class="cell q1"></span></div>
+            <div class="hrow"><span class="day">WED</span><span class="cell q2"></span><span class="cell q3"></span><span class="cell q4 hov"></span><span class="cell q1"></span><span class="cell q1"></span><span class="cell q2"></span><span class="cell q1"></span><span class="cell"></span><span class="cell"></span></div>
+            <div class="hrow"><span class="day">THU</span><span class="cell q3"></span><span class="cell q3"></span><span class="cell q4"></span><span class="cell q2"></span><span class="cell q1"></span><span class="cell q3"></span><span class="cell"></span><span class="cell"></span><span class="cell"></span></div>
+            <div class="hrow"><span class="day">FRI</span><span class="cell q2"></span><span class="cell q2"></span><span class="cell q1"></span><span class="cell"></span><span class="cell"></span><span class="cell"></span><span class="cell"></span><span class="cell"></span><span class="cell"></span></div>
+          </div>
+          <div class="hleg">less <i style="background:rgba(90,162,255,.10)"></i><i style="background:rgba(90,162,255,.26)"></i><i style="background:rgba(90,162,255,.48)"></i><i style="background:rgba(90,162,255,.78)"></i> more</div>
+          <div class="narr">Your week in one sentence: <b>mornings belong to deep work</b> — 71% of focused time landed before 12:00 — and Thursday afternoon's support interrupt cost one deep block but closed <b>#482</b> the same day.</div>
+        </div>
+
+        <!-- sessions -->
+        <div class="panel sess">
+          <div class="ph"><b>SESSIONS</b><span class="r">18 recorded · showing longest first</span></div>
+          <table>
+            <tr><th>FOCUS</th><th>DAY</th><th class="num">START</th><th class="num">LENGTH</th><th class="num">NOTES</th></tr>
+            <tr class="best"><td><span class="mark" style="background:#4a8ee8"></span>Improving AIDX</td><td>Tue</td><td class="num">09:12</td><td class="num"><span class="durbar" style="width:88px"></span>1h 28m</td><td class="num">3</td></tr>
+            <tr><td><span class="mark" style="background:#4a8ee8"></span>Improving AIDX</td><td>Thu</td><td class="num">11:05</td><td class="num"><span class="durbar" style="width:85px"></span>1h 25m</td><td class="num">1</td></tr>
+            <tr><td><span class="mark" style="background:#4a8ee8"></span>Improving AIDX</td><td>Mon</td><td class="num">09:31</td><td class="num"><span class="durbar" style="width:74px"></span>1h 14m</td><td class="num">4</td></tr>
+            <tr><td><span class="mark" style="background:#9678ea"></span>Component library docs</td><td>Wed</td><td class="num">10:04</td><td class="num"><span class="durbar" style="width:62px"></span>1h 02m</td><td class="num">2</td></tr>
+            <tr><td><span class="mark" style="background:#f43f5e"></span>Support ticket #482</td><td>Thu</td><td class="num">13:41</td><td class="num"><span class="durbar" style="width:52px"></span>52m</td><td class="num">2</td></tr>
+            <tr><td><span class="mark" style="background:#cb7a1c"></span>Wear OS sync</td><td>Mon</td><td class="num">14:20</td><td class="num"><span class="durbar" style="width:47px"></span>47m</td><td class="num">1</td></tr>
+            <tr><td><span class="mark" style="background:#cb7a1c"></span>Wear OS sync</td><td>Thu</td><td class="num">10:40</td><td class="num"><span class="durbar" style="width:25px"></span>25m</td><td class="num">0</td></tr>
+            <tr><td><span class="mark" style="background:#9678ea"></span>Component library docs</td><td>Fri</td><td class="num">09:15</td><td class="num"><span class="durbar" style="width:22px"></span>22m</td><td class="num">1</td></tr>
+          </table>
+        </div>
+      </div>
+
+      <!-- loose ends -->
+      <div class="loose">
+        <div class="ph"><b>LOOSE ENDS — DECIDE BEFORE MONDAY</b><span class="r">untouched &gt; 3 days, or waiting with no reply</span></div>
+        <div class="l-row"><span class="st" style="background:var(--amber)"></span><span class="t">Reading article — AIDX scoring paper</span><span class="why">untouched 4d · 1 note</span><div class="acts"><span class="a g">→ queue for mon</span><span class="a">archive</span></div></div>
+        <div class="l-row"><span class="st" style="background:var(--violet)"></span><span class="t">API quota bump</span><span class="why">waiting on support · 4d silent</span><div class="acts"><span class="a g">nudge</span><span class="a">drop</span></div></div>
+        <div class="l-row"><span class="st" style="background:var(--amber)"></span><span class="t">Plan v0.0.6 scope</span><span class="why">untouched 3d</span><div class="acts"><span class="a g">→ queue for mon</span><span class="a">someday</span></div></div>
+      </div>
+    </div>
+
+    <div class="heattip"><b>Wed 11:00</b> · 54 min focused · Component library docs</div>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="leg"><span class="n">1</span><p><b>Four numbers, chosen to be enough.</b> Focused time, deepest session, switches per day, loose ends. Deltas compare to last week in plain terms ("calmer"). No ring charts, no percentages of percentages — if a fifth tile ever feels necessary, one of these four was wrong.</p></div>
+  <div class="leg"><span class="n">2</span><p><b>The heat grid shows shape, not score.</b> One hue, four steps, minutes per hour — enough to see that mornings are deep and Friday tapers. Hover any cell for the exact figure. It's descriptive weather, deliberately too coarse to gamify.</p></div>
+  <div class="leg"><span class="n">3</span><p><b>Sessions are the ground truth.</b> A plain table, longest first, with an inline magnitude bar and the note count — because a session with zero notes at 25 minutes tells its own story. The best session of the week is quietly highlighted, not trophied.</p></div>
+  <div class="leg"><span class="n">4</span><p><b>The narrative line.</b> One generated sentence that reads the week back in words — where the time went, what an interrupt cost, what it bought. It's the line you'd write in a Friday standup, pre-written and honest.</p></div>
+  <div class="leg"><span class="n">5</span><p><b>Loose ends demand a verdict, not attention.</b> Everything untouched or silently blocked surfaces here with exactly two buttons. The review isn't done until each row has a decision — that's the whole ritual, and it takes four minutes.</p></div>
+  <div class="leg"><span class="n">6</span><p><b>Read-only by design.</b> You can't edit history here — no dragging sessions, no retouching the record. The only writable objects are the loose-end decisions, which feed Monday's queue. Trust in the record is the product.</p></div>
+</div>
+
+<div class="foot">LIMINAL FLOW · CLEAN SERIES — <a href="01-queue.html">1 · Queue</a> · <a href="02-day.html">2 · Day</a> · <a href="03-board.html">3 · Board</a></div>
+
+</body>
+</html>

--- a/docs/ux/exploration/3-clean-concepts/04-review.html
+++ b/docs/ux/exploration/3-clean-concepts/04-review.html
@@ -25,9 +25,9 @@
   .window{border-radius:12px;overflow:hidden;height:800px;display:flex;flex-direction:column;
     border:1px solid var(--line2);background:var(--bg);box-shadow:0 40px 90px rgba(0,0,0,.55)}
   .titlebar{height:42px;flex:none;display:flex;align-items:center;gap:12px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--surface)}
-  .lights{display:flex;gap:8px}
-  .lights i{width:12px;height:12px;border-radius:50%;display:block}
-  .lights i:nth-child(1){background:#ff5f57}.lights i:nth-child(2){background:#febc2e}.lights i:nth-child(3){background:#28c840}
+  .lights{display:flex;gap:16px;order:99;margin-left:12px;font:400 13px var(--mono);color:#8b93a7}
+  .lights i{font-style:normal}
+  .lights i:nth-child(1)::before{content:"−"}.lights i:nth-child(2)::before{content:"□"}.lights i:nth-child(3)::before{content:"×"}
   .weekpick{margin:0 auto;display:flex;align-items:center;gap:12px;font:600 13px var(--mono)}
   .weekpick .arr{color:var(--faint);border:1px solid var(--line);border-radius:6px;width:24px;height:24px;display:grid;place-items:center;font-size:12px}
   .tb-right{font:600 11px var(--mono);color:var(--faint)}
@@ -125,7 +125,7 @@
     <div class="titlebar">
       <div class="lights"><i></i><i></i><i></i></div>
       <div class="weekpick"><span class="arr">‹</span> Week 33 · Aug 11 – 15 <span class="arr">›</span></div>
-      <div class="tb-right">⌘E export · read-only</div>
+      <div class="tb-right">Ctrl+E export · read-only</div>
     </div>
 
     <div class="body">

--- a/docs/ux/exploration/3-clean-concepts/README.md
+++ b/docs/ux/exploration/3-clean-concepts/README.md
@@ -1,0 +1,58 @@
+# Liminal Flow — Clean Desktop Concepts
+
+Part of the desktop exploration. [`1-desktop-app/`](../1-desktop-app/) — the
+chosen design — translated the existing TUI to Tauri;
+[`2-metaphor-concepts/`](../2-metaphor-concepts/) explored
+expressive metaphors. This set starts from the ground up again but stays
+**serious**: conventional, legible UI structures — panes, columns, tables —
+executed with restraint. Any of these could ship to a professional audience
+without explanation.
+
+Each mock-up is a self-contained annotated HTML file — open in any browser.
+
+| # | Concept | Structure | One-line thesis |
+|---|---------|-----------|-----------------|
+| 1 | [FLOW / QUEUE](01-queue.html) | Nav · list · inspector (3-pane) | An operator's console: a fixed Now block, an explicitly ordered queue, single-key actions |
+| 2 | [FLOW / DAY](02-day.html) | Time column · context panel | A calendar that fills itself in — attention recorded as blocks, gaps kept honest |
+| 3 | [FLOW / BOARD](03-board.html) | Four fixed kanban columns | Personal kanban with an enforced WIP limit of one; swaps are explicit and fair |
+| 4 | [FLOW / REVIEW](04-review.html) | Stat tiles · heat grid · table | A read-only weekly close: four numbers, the sessions ledger, loose ends demanding decisions |
+
+## Shared design language
+
+- **Surfaces, not glows.** Flat panels (`#0e1320` on `#0a0d14`), 1 px hairline
+  borders, one radius scale. Color appears only as meaning: green = active,
+  amber = held/attention, violet = waiting/blocked, blue = interactive.
+- **Type does the hierarchy.** UI text 13–14 px; metadata in a mono face at
+  10–11 px; exactly one large number or title per view. No gradients inside
+  the working UI (the brand gradient stays in marketing).
+- **Keyboard-first, mouse-complete.** Every action shows its key; every key
+  has a visible button equivalent. Selection drives detail panes; nothing
+  opens a modal.
+- **One capture input per view,** always plain text, always bottom of the
+  frame, with deterministic placement rules (note → current focus; new item →
+  queue/Next).
+
+## The four, as a system
+
+These aren't competitors so much as **rooms of one house**, and they map onto
+the same store:
+
+- **Queue** is the working view (threads → queue items, branches → sub-tasks,
+  ordering is new but trivial to persist).
+- **Day** is the log view (a direct rendering of session events).
+- **Board** is Queue re-projected for people who think in columns — same
+  data, a WIP-1 constraint the core Five Rules already imply.
+- **Review** is the weekly read-only aggregation of the events table.
+
+A credible v1 desktop app is Queue + Day as two tabs, with Review generated
+weekly, and Board as an optional projection.
+
+## Data-viz notes (Review)
+
+- Sessions-table category marks use a categorical palette validated for the
+  dark surface `#0e1320` (lightness band, chroma floor, CVD ΔE, contrast):
+  `#4a8ee8` / `#cb7a1c` / `#9678ea` / `#f43f5e`, always paired with the text
+  label — never color alone.
+- The focus-by-hour grid is a single-hue sequential ramp (blue, four steps)
+  with a legend; magnitude bars in the table use one hue for all rows.
+- Stat tiles carry plain-language deltas instead of sparkline decoration.

--- a/docs/ux/exploration/README.md
+++ b/docs/ux/exploration/README.md
@@ -1,0 +1,22 @@
+# Liminal Flow — Desktop UX Exploration
+
+The full design exploration for a Flow desktop app, in three passes. The
+outcome: **[`1-desktop-app/`](1-desktop-app/) is the chosen design** and is
+being built as a Tauri app (tracked by the Flow Desktop epic on GitHub). The
+other two folders are the divergent explorations that informed that choice,
+kept for the record.
+
+| Folder | What it is | Status |
+|--------|------------|--------|
+| [`1-desktop-app/`](1-desktop-app/) | The desktop design: Workbench, Quick Capture, Companion & Tray, Flow Map | **Chosen — in build** |
+| [`2-metaphor-concepts/`](2-metaphor-concepts/) | Ground-up rethinks with expressive metaphors: Desk, One, Dialogue, Garden | Exploration, archived |
+| [`3-clean-concepts/`](3-clean-concepts/) | Ground-up rethinks with conventional structures: Queue, Day, Board, Review | Exploration, archived |
+
+Every mock-up is a self-contained HTML page (no external assets) with numbered
+annotation callouts — open it in any browser. `1-desktop-app/assets/` holds
+SVG renditions of the chosen screens for use in issues and docs.
+
+Ideas from the archived concepts worth stealing during the build: the
+re-entry note on every held item (Queue), honest gaps in the recorded day
+(Day), the explicit swap when focus is full (Board), and wilting-as-information
+rather than overdue-as-shame (Garden).


### PR DESCRIPTION
## Summary

Collects the full desktop UX exploration under `docs/ux/exploration/` and records the outcome: **`1-desktop-app/` is the chosen design** for the Flow desktop app (Tauri). The build is tracked by the Flow Desktop epic.

| Folder | Contents | Status |
|--------|----------|--------|
| `1-desktop-app/` | The desktop design: Workbench, Quick Capture, Companion & tray, Flow Map — plus SVG renditions of each screen and the epic dependency diagram under `assets/` | **Chosen — in build** |
| `2-metaphor-concepts/` | Ground-up rethinks with expressive metaphors: Desk, One, Dialogue, Garden | Exploration, archived |
| `3-clean-concepts/` | Ground-up rethinks with conventional structures: Queue, Day, Board, Review | Exploration, archived |

Every mock-up is a self-contained annotated HTML page — open it in any browser. The archived concepts stay in the tree because several of their ideas are earmarked for the build (re-entry notes, honest gaps, explicit focus swaps, wilting-as-information).

## Notes

- `1-desktop-app` pages retitled from "Desktop Concept · Mock-up" to "Desktop Design · Screen"; READMEs no longer describe the sets as numbered series.
- Cross-links between the three READMEs updated for the new folder layout.
- No code changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)